### PR TITLE
feat: Add Wild difficulty level and refactor character limits

### DIFF
--- a/src/game/challenge.rs
+++ b/src/game/challenge.rs
@@ -50,15 +50,6 @@ impl Challenge {
         self
     }
 
-    pub fn calculate_difficulty_by_char_count(&self) -> DifficultyLevel {
-        let char_count = self.code_content.chars().count();
-        match char_count {
-            0..=100 => DifficultyLevel::Easy,
-            101..=300 => DifficultyLevel::Normal,
-            301..=500 => DifficultyLevel::Hard,
-            _ => DifficultyLevel::Zen,
-        }
-    }
 
     pub fn get_display_title(&self) -> String {
         if let Some(ref path) = self.source_file_path {

--- a/src/game/screens/title_screen.rs
+++ b/src/game/screens/title_screen.rs
@@ -19,17 +19,18 @@ pub struct TitleScreen;
 impl TitleScreen {
     pub fn show() -> Result<TitleAction> {
         // Use default challenge counts when none provided
-        let default_counts = [0, 0, 0, 0];
+        let default_counts = [0, 0, 0, 0, 0];
         Self::show_with_challenge_counts(&default_counts)
     }
     
-    pub fn show_with_challenge_counts(challenge_counts: &[usize; 4]) -> Result<TitleAction> {
+    pub fn show_with_challenge_counts(challenge_counts: &[usize; 5]) -> Result<TitleAction> {
         let mut selected_difficulty = 1; // Start with Normal (index 1)
         let difficulties = [
-            ("Easy", DifficultyLevel::Easy, vec!["30-150 characters", "Short code snippets"]),
-            ("Normal", DifficultyLevel::Normal, vec!["120-350 characters", "Medium functions"]),
-            ("Hard", DifficultyLevel::Hard, vec!["300-700+ characters", "Long functions or classes"]),
-            ("Zen", DifficultyLevel::Zen, vec!["Entire files", "Complete files as challenges"]),
+            ("Easy", DifficultyLevel::Easy),
+            ("Normal", DifficultyLevel::Normal),
+            ("Hard", DifficultyLevel::Hard),
+            ("Wild", DifficultyLevel::Wild),
+            ("Zen", DifficultyLevel::Zen),
         ];
 
         let mut stdout = stdout();
@@ -135,12 +136,12 @@ impl TitleScreen {
         stdout: &mut std::io::Stdout, 
         center_row: u16, 
         center_col: u16,
-        difficulties: &[(&str, DifficultyLevel, Vec<&str>); 4],
+        difficulties: &[(&str, DifficultyLevel); 5],
         selected_difficulty: usize,
-        challenge_counts: &[usize; 4]
+        challenge_counts: &[usize; 5]
     ) -> Result<()> {
         let start_row = center_row + 1;
-        let (name, _, descriptions) = &difficulties[selected_difficulty];
+        let (name, difficulty_level) = &difficulties[selected_difficulty];
         let count = challenge_counts[selected_difficulty];
         
         // Clear previous difficulty display (multiple lines)
@@ -178,6 +179,7 @@ impl TitleScreen {
         execute!(stdout, ResetColor)?;
 
         // Line 3 & 4: Description lines
+        let descriptions = [difficulty_level.description(), difficulty_level.subtitle()];
         for (i, description) in descriptions.iter().enumerate() {
             let desc_col = center_col.saturating_sub(description.chars().count() as u16 / 2);
             execute!(stdout, MoveTo(desc_col, start_row + 2 + i as u16))?;

--- a/src/game/stage_builder.rs
+++ b/src/game/stage_builder.rs
@@ -17,9 +17,43 @@ pub enum GameMode {
 #[derive(Debug, Clone, PartialEq)]
 pub enum DifficultyLevel {
     Easy,    // ~100 characters
-    Normal,  // 200-300 characters  
+    Normal,  // ~200 characters  
     Hard,    // ~500 characters
+    Wild,    // Entire chunks, unpredictable length
     Zen,     // Entire file
+}
+
+impl DifficultyLevel {
+    pub fn char_limits(&self) -> (usize, usize) {
+        match self {
+            DifficultyLevel::Easy => (20, 100),
+            DifficultyLevel::Normal => (80, 200),
+            DifficultyLevel::Hard => (180, 500),
+            DifficultyLevel::Wild => (0, usize::MAX), // No limits - full chunks
+            DifficultyLevel::Zen => (0, usize::MAX),
+        }
+    }
+
+    pub fn description(&self) -> &'static str {
+        match self {
+            DifficultyLevel::Easy => "~100 characters",
+            DifficultyLevel::Normal => "~200 characters",
+            DifficultyLevel::Hard => "~500 characters",
+            DifficultyLevel::Wild => "Full chunks",
+            DifficultyLevel::Zen => "Entire files",
+        }
+    }
+
+    pub fn subtitle(&self) -> &'static str {
+        match self {
+            DifficultyLevel::Easy => "Short code snippets",
+            DifficultyLevel::Normal => "Medium functions",
+            DifficultyLevel::Hard => "Long functions or classes",
+            DifficultyLevel::Wild => "Unpredictable length chunks",
+            DifficultyLevel::Zen => "Complete files as challenges",
+        }
+    }
+
 }
 
 #[derive(Debug, Clone)]

--- a/src/game/stage_manager.rs
+++ b/src/game/stage_manager.rs
@@ -145,8 +145,8 @@ impl StageManager {
     }
 
     
-    fn count_challenges_by_difficulty(&self) -> [usize; 4] {
-        let mut counts = [0usize; 4];
+    fn count_challenges_by_difficulty(&self) -> [usize; 5] {
+        let mut counts = [0usize; 5];
         
         for challenge in &self.available_challenges {
             if let Some(ref difficulty) = challenge.difficulty_level {
@@ -154,7 +154,8 @@ impl StageManager {
                     DifficultyLevel::Easy => counts[0] += 1,
                     DifficultyLevel::Normal => counts[1] += 1,
                     DifficultyLevel::Hard => counts[2] += 1,
-                    DifficultyLevel::Zen => counts[3] += 1,
+                    DifficultyLevel::Wild => counts[3] += 1,
+                    DifficultyLevel::Zen => counts[4] += 1,
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add new **Wild** difficulty level between Hard and Zen for unpredictable chunk lengths
- Refactor DifficultyLevel enum to embed configuration values and methods directly
- Update character limits to be more manageable: Easy ~100, Normal ~200, Hard ~500 chars
- Wild level uses full chunks without character restrictions for maximum variability
- Clean up unused methods (from_char_count, calculate_difficulty_by_char_count)

## Changes

### New Wild Difficulty Level
- Positioned between Hard and Zen
- Uses full code chunks without size restrictions
- Provides unpredictable challenge lengths for variety
- Description: "Full chunks" / "Unpredictable length chunks"

### DifficultyLevel Refactoring
- Added `char_limits()` method to centralize character limit configuration
- Added `description()` and `subtitle()` methods for UI text
- Removed unused `from_char_count()` and `calculate_difficulty_by_char_count()` methods

### Updated Character Limits
- **Easy**: 20-100 chars (~100 chars display)
- **Normal**: 80-200 chars (~200 chars display)
- **Hard**: 180-500 chars (~500 chars display)
- **Wild**: No limits (full chunks)
- **Zen**: No limits (entire files)

### UI Updates
- Updated title screen to support 5 difficulty levels
- Updated array sizing from `[usize; 4]` to `[usize; 5]`
- All difficulty descriptions now use enum methods

## Test plan

- [x] Code compiles without errors
- [x] Application launches and shows help
- [x] Title screen displays all 5 difficulty levels
- [x] Challenge generation works for all difficulty levels
- [ ] Wild difficulty generates appropriate full-chunk challenges
- [ ] UI navigation works with 5 options

🤖 Generated with [Claude Code](https://claude.ai/code)