### PR TITLE
feat: Add session summary screen with comprehensive statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "ctrlc",
  "glob",
  "ignore",
+ "once_cell",
  "paste",
  "rand",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0"
 ctrlc = "3.4.7"
 uuid = { version = "1.0", features = ["v4"] }
 rand = { version = "0.8", features = ["std_rng"] }
+once_cell = "1.19"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -10,8 +10,10 @@ pub mod ascii_digits;
 pub mod ascii_rank_titles_generated;
 pub mod typing_animation;
 pub mod rank_messages;
+pub mod session_tracker;
 
 pub use screens::TypingScreen;
 pub use challenge::Challenge;
 pub use stage_manager::StageManager;
 pub use stage_builder::{StageBuilder, GameMode, DifficultyLevel, StageConfig};
+pub use session_tracker::{SessionTracker, SessionSummary};

--- a/src/game/screens/exit_summary_screen.rs
+++ b/src/game/screens/exit_summary_screen.rs
@@ -1,0 +1,170 @@
+use crate::Result;
+use crate::game::{SessionSummary, ascii_digits::get_digit_patterns};
+use crossterm::{
+    cursor::MoveTo,
+    event::{self, Event},
+    execute,
+    style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor},
+    terminal::{self, ClearType},
+};
+use std::io::{stdout, Write};
+
+#[derive(Debug)]
+pub enum ExitAction {
+    Exit,
+}
+
+pub struct ExitSummaryScreen;
+
+impl ExitSummaryScreen {
+    fn create_ascii_numbers(score: &str) -> Vec<String> {
+        let digit_patterns = get_digit_patterns();
+        let max_height = 4;
+        let mut result = vec![String::new(); max_height];
+
+        for ch in score.chars() {
+            if let Some(digit) = ch.to_digit(10) {
+                let pattern = &digit_patterns[digit as usize];
+                for (i, line) in pattern.iter().enumerate() {
+                    result[i].push_str(line);
+                    result[i].push(' ');
+                }
+            }
+        }
+
+        result
+    }
+
+    pub fn show(session_summary: &SessionSummary) -> Result<ExitAction> {
+        let mut stdout = stdout();
+        execute!(stdout, terminal::Clear(ClearType::All))?;
+        
+        let (terminal_width, terminal_height) = terminal::size()?;
+        let center_row = terminal_height / 2;
+        let center_col = terminal_width / 2;
+
+        let title = "🎮 SESSION SUMMARY 🎮";
+        let title_col = center_col.saturating_sub(title.len() as u16 / 2);
+        execute!(stdout, MoveTo(title_col, center_row.saturating_sub(12)))?;
+        execute!(stdout, SetAttribute(Attribute::Bold), SetForegroundColor(Color::Yellow))?;
+        execute!(stdout, Print(&title))?;
+        execute!(stdout, ResetColor)?;
+
+        // Show session duration
+        let duration_text = format!("Session Duration: {:.1} minutes", session_summary.total_session_time.as_secs_f64() / 60.0);
+        let duration_col = center_col.saturating_sub(duration_text.len() as u16 / 2);
+        execute!(stdout, MoveTo(duration_col, center_row.saturating_sub(10)))?;
+        execute!(stdout, SetForegroundColor(Color::Cyan))?;
+        execute!(stdout, Print(&duration_text))?;
+        execute!(stdout, ResetColor)?;
+
+        // Show completion status
+        let completion_status = session_summary.get_session_completion_status();
+        let status_col = center_col.saturating_sub(completion_status.len() as u16 / 2);
+        execute!(stdout, MoveTo(status_col, center_row.saturating_sub(9)))?;
+        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(stdout, Print(&completion_status))?;
+        execute!(stdout, ResetColor)?;
+
+        // Show total score as large ASCII
+        let score_label = "TOTAL SESSION SCORE";
+        let score_label_col = center_col.saturating_sub(score_label.len() as u16 / 2);
+        execute!(stdout, MoveTo(score_label_col, center_row.saturating_sub(7)))?;
+        execute!(stdout, SetAttribute(Attribute::Bold), SetForegroundColor(Color::Cyan))?;
+        execute!(stdout, Print(score_label))?;
+        execute!(stdout, ResetColor)?;
+
+        let score_value = format!("{:.0}", session_summary.session_score);
+        let ascii_numbers = Self::create_ascii_numbers(&score_value);
+        let score_start_row = center_row.saturating_sub(6);
+        
+        for (row_index, line) in ascii_numbers.iter().enumerate() {
+            let line_col = center_col.saturating_sub(line.len() as u16 / 2);
+            execute!(stdout, MoveTo(line_col, score_start_row + row_index as u16))?;
+            execute!(stdout, SetAttribute(Attribute::Bold), SetForegroundColor(Color::Green))?;
+            execute!(stdout, Print(line))?;
+            execute!(stdout, ResetColor)?;
+        }
+
+        // Show session statistics
+        let stats_start_row = center_row.saturating_sub(1);
+        
+        let mut stats_lines = vec![
+            format!("Overall CPM: {:.1} | WPM: {:.1} | Accuracy: {:.1}%", 
+                session_summary.overall_cpm, session_summary.overall_wpm, session_summary.overall_accuracy),
+            format!("Total Keystrokes: {} | Mistakes: {} | Challenges: {}/{}", 
+                session_summary.total_keystrokes, session_summary.total_mistakes,
+                session_summary.total_challenges_completed, session_summary.total_challenges_attempted),
+        ];
+
+        if session_summary.total_skips_used > 0 {
+            stats_lines.push(format!("Skips Used: {}", session_summary.total_skips_used));
+        }
+
+        for (i, line) in stats_lines.iter().enumerate() {
+            let line_col = center_col.saturating_sub(line.len() as u16 / 2);
+            execute!(stdout, MoveTo(line_col, stats_start_row + i as u16))?;
+            execute!(stdout, SetForegroundColor(Color::White))?;
+            execute!(stdout, Print(line))?;
+            execute!(stdout, ResetColor)?;
+        }
+
+        // Show best/worst performance if we have completed challenges
+        if session_summary.total_challenges_completed > 0 {
+            let performance_start_row = stats_start_row + stats_lines.len() as u16 + 1;
+            
+            let performance_lines = vec![
+                format!("Best Stage: {:.1} WPM, {:.1}% accuracy", 
+                    session_summary.best_stage_wpm, session_summary.best_stage_accuracy),
+                format!("Worst Stage: {:.1} WPM, {:.1}% accuracy", 
+                    session_summary.worst_stage_wpm, session_summary.worst_stage_accuracy),
+            ];
+
+            for (i, line) in performance_lines.iter().enumerate() {
+                let line_col = center_col.saturating_sub(line.len() as u16 / 2);
+                execute!(stdout, MoveTo(line_col, performance_start_row + i as u16))?;
+                execute!(stdout, SetForegroundColor(Color::Grey))?;
+                execute!(stdout, Print(line))?;
+                execute!(stdout, ResetColor)?;
+            }
+        }
+
+
+        // Show exit options
+        let options_start = if session_summary.total_challenges_completed > 0 {
+            stats_start_row + stats_lines.len() as u16 + 4
+        } else {
+            stats_start_row + stats_lines.len() as u16 + 2
+        };
+        // Show thanks message
+        let thanks_message = "Thanks for playing GitType!";
+        let thanks_col = center_col.saturating_sub(thanks_message.len() as u16 / 2);
+        execute!(stdout, MoveTo(thanks_col, options_start))?;
+        execute!(stdout, SetAttribute(Attribute::Bold), SetForegroundColor(Color::Green))?;
+        execute!(stdout, Print(thanks_message))?;
+        execute!(stdout, ResetColor)?;
+
+        let options = vec![
+            "Press any key to exit",
+        ];
+        
+        for (i, option) in options.iter().enumerate() {
+            let option_col = center_col.saturating_sub(option.len() as u16 / 2);
+            execute!(stdout, MoveTo(option_col, options_start + 2 + i as u16))?;
+            execute!(stdout, SetForegroundColor(Color::Yellow))?;
+            execute!(stdout, Print(option))?;
+            execute!(stdout, ResetColor)?;
+        }
+
+        stdout.flush()?;
+
+        // Wait for any key press
+        loop {
+            if event::poll(std::time::Duration::from_millis(100))? {
+                if let Event::Key(_) = event::read()? {
+                    return Ok(ExitAction::Exit);
+                }
+            }
+        }
+    }
+}

--- a/src/game/screens/mod.rs
+++ b/src/game/screens/mod.rs
@@ -4,6 +4,7 @@ pub mod countdown_screen;
 pub mod typing_screen;
 pub mod loading_screen;
 pub mod animation_screen;
+pub mod exit_summary_screen;
 
 pub use title_screen::{TitleScreen, TitleAction};
 pub use result_screen::{ResultScreen, ResultAction};
@@ -11,3 +12,4 @@ pub use countdown_screen::CountdownScreen;
 pub use typing_screen::TypingScreen;
 pub use loading_screen::LoadingScreen;
 pub use animation_screen::AnimationScreen;
+pub use exit_summary_screen::{ExitSummaryScreen, ExitAction};

--- a/src/game/session_tracker.rs
+++ b/src/game/session_tracker.rs
@@ -1,0 +1,139 @@
+use std::time::{Duration, Instant};
+use crate::scoring::{TypingMetrics, ScoringEngine};
+
+#[derive(Debug, Clone)]
+pub struct SessionSummary {
+    pub session_start_time: Instant,
+    pub total_session_time: Duration,
+    pub total_challenges_completed: usize,
+    pub total_challenges_attempted: usize,
+    pub total_skips_used: usize,
+    pub overall_accuracy: f64,
+    pub overall_wpm: f64,
+    pub overall_cpm: f64,
+    pub total_keystrokes: usize,
+    pub total_mistakes: usize,
+    pub best_stage_wpm: f64,
+    pub worst_stage_wpm: f64,
+    pub best_stage_accuracy: f64,
+    pub worst_stage_accuracy: f64,
+    pub session_score: f64,
+}
+
+impl SessionSummary {
+    pub fn new() -> Self {
+        Self {
+            session_start_time: Instant::now(),
+            total_session_time: Duration::default(),
+            total_challenges_completed: 0,
+            total_challenges_attempted: 0,
+            total_skips_used: 0,
+            overall_accuracy: 0.0,
+            overall_wpm: 0.0,
+            overall_cpm: 0.0,
+            total_keystrokes: 0,
+            total_mistakes: 0,
+            best_stage_wpm: 0.0,
+            worst_stage_wpm: f64::MAX,
+            best_stage_accuracy: 0.0,
+            worst_stage_accuracy: f64::MAX,
+            session_score: 0.0,
+        }
+    }
+
+    pub fn add_stage_result(&mut self, _stage_name: String, metrics: TypingMetrics, engine: &ScoringEngine) {
+        self.total_challenges_completed += 1;
+        self.total_keystrokes += engine.total_chars();
+        self.total_mistakes += metrics.mistakes;
+        self.session_score += metrics.challenge_score;
+        
+        // Track best/worst performance
+        if metrics.wpm > self.best_stage_wpm {
+            self.best_stage_wpm = metrics.wpm;
+        }
+        if metrics.wpm < self.worst_stage_wpm {
+            self.worst_stage_wpm = metrics.wpm;
+        }
+        if metrics.accuracy > self.best_stage_accuracy {
+            self.best_stage_accuracy = metrics.accuracy;
+        }
+        if metrics.accuracy < self.worst_stage_accuracy {
+            self.worst_stage_accuracy = metrics.accuracy;
+        }
+    }
+
+    pub fn add_skip(&mut self) {
+        self.total_skips_used += 1;
+        self.total_challenges_attempted += 1;
+    }
+
+    pub fn finalize_session(&mut self) {
+        self.total_session_time = self.session_start_time.elapsed();
+        self.total_challenges_attempted = self.total_challenges_completed + self.total_skips_used;
+        
+        // Calculate overall metrics - simplified since we don't track individual stage times
+        if self.total_session_time.as_secs() > 0 && self.total_keystrokes > 0 {
+            self.overall_cpm = (self.total_keystrokes as f64 / self.total_session_time.as_secs_f64()) * 60.0;
+            self.overall_wpm = self.overall_cpm / 5.0;
+            self.overall_accuracy = ((self.total_keystrokes.saturating_sub(self.total_mistakes)) as f64 / self.total_keystrokes as f64) * 100.0;
+        }
+        
+        // Handle edge cases for worst performance
+        if self.worst_stage_wpm == f64::MAX {
+            self.worst_stage_wpm = 0.0;
+        }
+        if self.worst_stage_accuracy == f64::MAX {
+            self.worst_stage_accuracy = 0.0;
+        }
+    }
+
+    pub fn get_session_completion_status(&self) -> String {
+        match (self.total_challenges_completed, self.total_skips_used) {
+            (0, 0) => "No challenges attempted".to_string(),
+            (completed, 0) if completed > 0 => format!("Perfect session! {} challenges completed", completed),
+            (completed, skips) => format!("{} completed, {} skipped", completed, skips),
+        }
+    }
+}
+
+impl Default for SessionSummary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+pub struct SessionTracker {
+    summary: SessionSummary,
+}
+
+impl SessionTracker {
+    pub fn new() -> Self {
+        Self {
+            summary: SessionSummary::new(),
+        }
+    }
+
+    pub fn record_stage_completion(&mut self, stage_name: String, metrics: TypingMetrics, engine: &ScoringEngine) {
+        self.summary.add_stage_result(stage_name, metrics, engine);
+    }
+
+    pub fn record_skip(&mut self) {
+        self.summary.add_skip();
+    }
+
+    pub fn finalize_and_get_summary(mut self) -> SessionSummary {
+        self.summary.finalize_session();
+        self.summary
+    }
+
+    pub fn get_current_summary(&self) -> &SessionSummary {
+        &self.summary
+    }
+}
+
+impl Default for SessionTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use gittype::game::StageManager;
+use gittype::game::{StageManager, stage_manager::show_session_summary_on_interrupt};
 use gittype::extractor::{ExtractionOptions, RepositoryLoader, ProgressReporter};
 use gittype::game::screens::loading_screen::LoadingScreen;
 use std::path::PathBuf;
@@ -63,9 +63,7 @@ enum Commands {
 fn main() -> anyhow::Result<()> {
     // Set up Ctrl+C handler
     ctrlc::set_handler(move || {
-        // Clean up terminal state if needed
-        let _ = crossterm::terminal::disable_raw_mode();
-        println!("\n\nInterrupted by user");
+        show_session_summary_on_interrupt();
         std::process::exit(0);
     }).expect("Error setting Ctrl-C handler");
     


### PR DESCRIPTION
## Summary
Add application exit screen that displays comprehensive summary of all activities during the current session, addressing issue #24.

### Features
- **Session-wide statistics tracking**: Time, total score, WPM/CPM, accuracy
- **Best/worst performance metrics**: Track peak and lowest performance per session
- **Challenge completion tracking**: Shows completed vs attempted challenges, skip counts
- **Comprehensive exit summary**: Displayed on all exit paths (title screen, game completion, Ctrl+C)
- **Clean terminal UI**: No println output, all messages shown in terminal UI screens

### Technical Implementation
- `SessionTracker` and `SessionSummary` for real-time session data tracking
- `ExitSummaryScreen` with ASCII art score display and comprehensive statistics
- Global session tracker for Ctrl+C interrupt handling
- Integration with existing game flow at all exit points

### Exit Scenarios Covered
- ✅ Exiting from title screen → Session summary
- ✅ Exiting after completing game stages → Session summary  
- ✅ Ctrl+C interrupt → Session summary (if session data available)
- ✅ Clean "Thanks for playing GitType!" message in UI

### UI/UX Improvements
- Large ASCII art display for total session score
- Organized statistics layout with clear sections
- Simplified exit flow (press any key to exit)
- Consistent branding and styling

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)