### PR TITLE
Fix git repository path recognition for relative paths and subdirectories

### DIFF
--- a/src/extractor/git_info.rs
+++ b/src/extractor/git_info.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+use std::process::Command;
+use serde::{Deserialize, Serialize};
+use crate::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GitRepositoryInfo {
+    pub user_name: String,
+    pub repository_name: String,
+    pub remote_url: String,
+    pub branch: Option<String>,
+    pub commit_hash: Option<String>,
+    pub is_dirty: bool,
+}
+
+pub struct GitInfoExtractor;
+
+impl GitInfoExtractor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn extract_git_info(repo_path: &Path) -> Result<Option<GitRepositoryInfo>> {
+        // Canonicalize the path to handle relative paths like ../../
+        let canonical_path = match repo_path.canonicalize() {
+            Ok(path) => path,
+            Err(_) => {
+                // If canonicalization fails, the path might not exist
+                return Ok(None);
+            }
+        };
+        
+        // Find git repository root (may be parent directory)
+        let git_root = match Self::find_git_repository_root(&canonical_path) {
+            Some(root) => root,
+            None => return Ok(None),
+        };
+
+        let remote_url = Self::get_remote_url(&git_root)?;
+        if let Some((user_name, repository_name)) = Self::parse_remote_url(&remote_url) {
+            let branch = Self::get_current_branch(&git_root).ok();
+            let commit_hash = Self::get_current_commit_hash(&git_root).ok();
+            let is_dirty = Self::is_working_directory_dirty(&git_root).unwrap_or(false);
+
+            Ok(Some(GitRepositoryInfo {
+                user_name,
+                repository_name,
+                remote_url,
+                branch,
+                commit_hash,
+                is_dirty,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn find_git_repository_root(start_path: &Path) -> Option<std::path::PathBuf> {
+        let mut current_path = start_path;
+        
+        loop {
+            let git_dir = current_path.join(".git");
+            if git_dir.exists() {
+                return Some(current_path.to_path_buf());
+            }
+            
+            // Move to parent directory
+            match current_path.parent() {
+                Some(parent) => current_path = parent,
+                None => return None, // Reached root directory without finding .git
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn is_git_repository(repo_path: &Path) -> bool {
+        let git_dir = repo_path.join(".git");
+        git_dir.exists()
+    }
+
+    fn get_remote_url(repo_path: &Path) -> Result<String> {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(["remote", "get-url", "origin"])
+            .output()
+            .map_err(|e| crate::GitTypeError::IoError(e))?;
+
+        if !output.status.success() {
+            return Err(crate::GitTypeError::ExtractionFailed("Failed to get remote URL".to_string()));
+        }
+
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(url)
+    }
+
+    fn parse_remote_url(url: &str) -> Option<(String, String)> {
+        // Handle HTTPS URLs like https://github.com/user/repo.git
+        if url.starts_with("https://github.com/") {
+            let path = url.strip_prefix("https://github.com/")?;
+            let path = path.strip_suffix(".git").unwrap_or(path);
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() == 2 {
+                return Some((parts[0].to_string(), parts[1].to_string()));
+            }
+        }
+        
+        // Handle SSH URLs like git@github.com:user/repo.git
+        if url.starts_with("git@github.com:") {
+            let path = url.strip_prefix("git@github.com:")?;
+            let path = path.strip_suffix(".git").unwrap_or(path);
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() == 2 {
+                return Some((parts[0].to_string(), parts[1].to_string()));
+            }
+        }
+        
+        // Handle SSH URLs like ssh://git@github.com/user/repo.git or ssh://git@github.com/user/repo
+        if url.starts_with("ssh://git@github.com/") {
+            let path = url.strip_prefix("ssh://git@github.com/")?;
+            let path = path.strip_suffix(".git").unwrap_or(path);
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() == 2 {
+                return Some((parts[0].to_string(), parts[1].to_string()));
+            }
+        }
+
+        None
+    }
+
+    fn get_current_branch(repo_path: &Path) -> Result<String> {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(["branch", "--show-current"])
+            .output()
+            .map_err(|e| crate::GitTypeError::IoError(e))?;
+
+        if !output.status.success() {
+            return Err(crate::GitTypeError::ExtractionFailed("Failed to get current branch".to_string()));
+        }
+
+        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(branch)
+    }
+
+    fn get_current_commit_hash(repo_path: &Path) -> Result<String> {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .map_err(|e| crate::GitTypeError::IoError(e))?;
+
+        if !output.status.success() {
+            return Err(crate::GitTypeError::ExtractionFailed("Failed to get current commit hash".to_string()));
+        }
+
+        let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(hash)
+    }
+
+    fn is_working_directory_dirty(repo_path: &Path) -> Result<bool> {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(["status", "--porcelain"])
+            .output()
+            .map_err(|e| crate::GitTypeError::IoError(e))?;
+
+        if !output.status.success() {
+            return Err(crate::GitTypeError::ExtractionFailed("Failed to check working directory status".to_string()));
+        }
+
+        let status = String::from_utf8_lossy(&output.stdout);
+        Ok(!status.trim().is_empty())
+    }
+}

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1,6 +1,7 @@
 pub mod centered_progress;
 pub mod challenge_converter;
 pub mod chunk;
+pub mod git_info;
 pub mod language;
 pub mod parser;
 pub mod progress;
@@ -9,6 +10,7 @@ pub mod repository_loader;
 pub use centered_progress::CenteredProgressReporter;
 pub use challenge_converter::ChallengeConverter;
 pub use chunk::{CodeChunk, ChunkType};
+pub use git_info::{GitInfoExtractor, GitRepositoryInfo};
 pub use language::Language;
 pub use parser::{CodeExtractor, ExtractionOptions};
 pub use progress::{ConsoleProgressReporter, NoOpProgressReporter, ProgressReporter};

--- a/src/extractor/repository_loader.rs
+++ b/src/extractor/repository_loader.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
 use crate::game::Challenge;
 use crate::{Result, GitTypeError};
-use super::{CodeExtractor, ExtractionOptions, ChallengeConverter, ProgressReporter, NoOpProgressReporter};
+use super::{CodeExtractor, ExtractionOptions, ChallengeConverter, ProgressReporter, NoOpProgressReporter, GitInfoExtractor, GitRepositoryInfo};
 
 pub struct RepositoryLoader {
     extractor: CodeExtractor,
     converter: ChallengeConverter,
+    git_info: Option<GitRepositoryInfo>,
 }
 
 impl RepositoryLoader {
@@ -16,6 +17,7 @@ impl RepositoryLoader {
         Ok(Self {
             extractor,
             converter,
+            git_info: None,
         })
     }
 
@@ -36,6 +38,9 @@ impl RepositoryLoader {
         if !repo_path.exists() {
             return Err(GitTypeError::RepositoryNotFound(repo_path.to_path_buf()));
         }
+
+        // Extract git information
+        self.git_info = GitInfoExtractor::extract_git_info(repo_path)?;
 
         let extraction_options = options.unwrap_or_default();
         let chunks = self.extractor.extract_chunks_with_progress(repo_path, extraction_options, progress)?;
@@ -134,4 +139,9 @@ impl RepositoryLoader {
         
         Ok(zen_challenges)
     }
+
+    pub fn get_git_info(&self) -> &Option<GitRepositoryInfo> {
+        &self.git_info
+    }
+
 }

--- a/src/game/screens/loading_screen.rs
+++ b/src/game/screens/loading_screen.rs
@@ -154,7 +154,7 @@ impl LoadingScreen {
         let size = frame.size();
         
         // Calculate total content height
-        let content_height = 6 + 2 + 3 + 3; // Logo + Loading message + Phase + Progress
+        let content_height = 2 + 6 + 3 + 3; // Loading message + Description + Phase + Progress
         let vertical_margin = (size.height.saturating_sub(content_height)) / 2;
         
         // Create vertical centering layout
@@ -171,18 +171,18 @@ impl LoadingScreen {
         let main_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(6),  // Logo
                 Constraint::Length(2),  // Loading message
+                Constraint::Length(6),  // Description
                 Constraint::Length(3),  // Phase
                 Constraint::Length(3),  // Progress
             ])
             .split(vertical_layout[1]);
-
-        // Draw logo
-        self.draw_logo(frame, main_layout[0]);
         
         // Draw loading message
-        self.draw_loading_message(frame, main_layout[1]);
+        self.draw_loading_message(frame, main_layout[0]);
+        
+        // Draw description
+        self.draw_description(frame, main_layout[1]);
         
         // Draw phase
         self.draw_phase(frame, main_layout[2]);
@@ -191,29 +191,10 @@ impl LoadingScreen {
         self.draw_progress(frame, main_layout[3]);
     }
 
-    fn draw_logo(&self, frame: &mut Frame, area: Rect) {
-        let logo_lines = vec![
-            "╔═══╗─╔══╗─╔════╗────╔════╗─╔╗──╔╗─╔═══╗─╔═══╗",
-            "║╔═╗║─╚╣╠╝─║╔╗╔╗║────║╔╗╔╗║─║╚╗╔╝║─║╔═╗║─║╔══╝",
-            "║║─╚╝──║║──╚╝║║╚╝────╚╝║║╚╝─╚╗╚╝╔╝─║╚═╝║─║╚══╗",
-            "║║╔═╗──║║────║║────────║║────╚╗╔╝──║╔══╝─║╔══╝",
-            "║╚╩═║─╔╣╠╗───║║────────║║─────║║───║║────║╚══╗",
-            "╚═══╝─╚══╝───╚╝────────╚╝─────╚╝───╚╝────╚═══╝",
-        ];
-
-        let logo_text: Vec<Line> = logo_lines.iter()
-            .map(|line| Line::from(Span::styled(*line, Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))))
-            .collect();
-
-        let logo = Paragraph::new(logo_text)
-            .alignment(Alignment::Center);
-        
-        frame.render_widget(logo, area);
-    }
 
     fn draw_loading_message(&self, frame: &mut Frame, area: Rect) {
         let loading_msg = Line::from(vec![
-            Span::styled("🚀 ", Style::default().fg(Color::Yellow)),
+            Span::styled("» ", Style::default().fg(Color::Yellow)),
             Span::styled("Loading...", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
         ]);
 
@@ -221,6 +202,48 @@ impl LoadingScreen {
             .alignment(Alignment::Center);
         
         frame.render_widget(loading, area);
+    }
+
+    fn draw_description(&self, frame: &mut Frame, area: Rect) {
+        let current_step = *self.current_step.lock().unwrap();
+        
+        // Define steps with their descriptions
+        let steps = [
+            "Scanning repository files",
+            "Extracting functions, classes, and code blocks", 
+            "Parsing AST and analyzing code structure",
+            "Generating challenges across difficulty levels",
+            "Preparing content for optimal typing practice"
+        ];
+        
+        let mut description_lines = vec![
+            Line::from(Span::styled(
+                "Analyzing your repository to create typing challenges...", 
+                Style::default().fg(Color::Gray)
+            )),
+        ];
+        
+        // Add steps with checkmarks/progress indicators
+        for (i, step_desc) in steps.iter().enumerate() {
+            let step_num = i + 1;
+            let (icon, color) = if step_num < current_step {
+                ("✓", Color::Green)
+            } else if step_num == current_step {
+                ("•", Color::Yellow)
+            } else {
+                ("◦", Color::DarkGray)
+            };
+            
+            description_lines.push(Line::from(vec![
+                Span::styled(format!("{} ", icon), Style::default().fg(color)),
+                Span::styled(*step_desc, Style::default().fg(if step_num <= current_step { Color::Gray } else { Color::DarkGray })),
+            ]));
+        }
+
+        let description_paragraph = Paragraph::new(description_lines)
+            .alignment(Alignment::Center);
+        
+        frame.render_widget(description_paragraph, area);
     }
 
     fn draw_phase(&self, frame: &mut Frame, area: Rect) {
@@ -232,9 +255,9 @@ impl LoadingScreen {
         }
 
         let phase_text = if *current_phase == "Completed" {
-            "✅ Loading complete!"
+            "✓ Loading complete!"
         } else {
-            &format!("🔄 {}/{} {}...", current_step, self.total_steps, current_phase)
+            &format!("• {}/{} {}...", current_step, self.total_steps, current_phase)
         };
 
         let phase_line = Line::from(Span::styled(

--- a/src/game/stage_manager.rs
+++ b/src/game/stage_manager.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use crate::scoring::{TypingMetrics, ScoringEngine};
+use crate::extractor::GitRepositoryInfo;
 use crossterm::terminal;
 use std::sync::{Arc, Mutex};
 use once_cell::sync::Lazy;
@@ -22,6 +23,7 @@ pub struct StageManager {
     stage_engines: Vec<(String, ScoringEngine)>,
     current_game_mode: Option<GameMode>,
     session_tracker: SessionTracker,
+    git_info: Option<GitRepositoryInfo>,
 }
 
 impl StageManager {
@@ -33,7 +35,12 @@ impl StageManager {
             stage_engines: Vec::new(),
             current_game_mode: None,
             session_tracker: SessionTracker::new(),
+            git_info: None,
         }
+    }
+    
+    pub fn set_git_info(&mut self, git_info: Option<GitRepositoryInfo>) {
+        self.git_info = git_info;
     }
 
     pub fn run_session(&mut self) -> Result<()> {
@@ -57,7 +64,7 @@ impl StageManager {
             // Count challenges by difficulty level
             let challenge_counts = self.count_challenges_by_difficulty();
             
-            match TitleScreen::show_with_challenge_counts(&challenge_counts)? {
+            match TitleScreen::show_with_challenge_counts_and_git_info(&challenge_counts, self.git_info.as_ref())? {
                 TitleAction::Start(difficulty) => {
                     // Build stages based on selected difficulty using pre-generated challenges
                     let game_mode = GameMode::Custom {

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,7 @@ fn main() -> anyhow::Result<()> {
                 
                 // Create StageManager with pre-generated challenges
                 let mut stage_manager = StageManager::new(available_challenges);
+                stage_manager.set_git_info(loader.get_git_info().clone());
                 match stage_manager.run_session() {
                     Ok(_) => {
                         // println!("Thanks for playing GitType!");


### PR DESCRIPTION
## Summary
- Add support for `ssh://git@github.com/` URL format parsing
- Implement git repository root detection for subdirectories  
- Fix relative path handling with path canonicalization
- Add git repository info display on title screen

## Changes
- **GitInfoExtractor**: New module for git repository information extraction
- **SSH URL Support**: Parse `ssh://git@github.com/user/repo` format URLs
- **Subdirectory Support**: Find git repository root by traversing parent directories
- **Path Canonicalization**: Handle relative paths like `../../repo-name` correctly
- **Title Screen**: Display git info at bottom of title screen

## Test plan
- [x] Test with current directory (.)
- [x] Test with relative paths (../../orderlyjp/orderly-server)
- [x] Test with subdirectories (../../orderlyjp/orderly-server/test-subdir)
- [x] Test with various SSH URL formats
- [x] Test with non-existent paths

🤖 Generated with [Claude Code](https://claude.ai/code)