### PR TITLE
feat: improve Ctrl+C handling and session statistics tracking

### DIFF
--- a/src/game/screens/countdown_screen.rs
+++ b/src/game/screens/countdown_screen.rs
@@ -146,7 +146,9 @@ impl CountdownScreen {
             if event::poll(std::time::Duration::from_millis(10))? {
                 if let Event::Key(key) = event::read()? {
                     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-                        return Err(crate::error::GitTypeError::TerminalError("Interrupted by user".to_string()));
+                        // Use global session tracker to show summary
+                        crate::game::stage_manager::show_session_summary_on_interrupt();
+                        std::process::exit(0);
                     }
                 }
             }

--- a/src/game/screens/exit_summary_screen.rs
+++ b/src/game/screens/exit_summary_screen.rs
@@ -93,7 +93,7 @@ impl ExitSummaryScreen {
             format!("Overall CPM: {:.1} | WPM: {:.1} | Accuracy: {:.1}%", 
                 session_summary.overall_cpm, session_summary.overall_wpm, session_summary.overall_accuracy),
             format!("Total Keystrokes: {} | Mistakes: {} | Challenges: {}/{}", 
-                session_summary.total_keystrokes, session_summary.total_mistakes,
+                session_summary.total_effort_keystrokes(), session_summary.total_effort_mistakes(),
                 session_summary.total_challenges_completed, session_summary.total_challenges_attempted),
         ];
 


### PR DESCRIPTION
## Summary
- Improve Ctrl+C handling to show session summary instead of direct exit
- Separate completed and partial effort tracking in session statistics
- Better user experience for interrupted typing sessions

## Changes Made

### 1. Enhanced Ctrl+C Handling
- **TypingScreen**: Ctrl+C returns `GameState::Exit` instead of direct process exit
- **CountdownScreen**: Ctrl+C shows session summary via global session tracker
- **StageManager**: Proper session summary display for all exit scenarios
- Fixed raw mode handling for ExitSummaryScreen input acceptance

### 2. Improved Session Statistics
- Added `total_partial_effort_keystrokes` and `total_partial_effort_mistakes` fields
- Separated completed stages (for scoring) from partial efforts (Skip/Exit)
- Added computed properties: `total_effort_keystrokes()`, `total_effort_mistakes()`
- Maintained data integrity: completed ∩ partial = ∅, total = completed ∪ partial

### 3. Better User Experience
- Skip/Exit attempts now contribute to total effort statistics
- Session summary shows actual typing effort including interrupted attempts
- More accurate representation of user activity

## Test Plan
- [x] Test Ctrl+C during typing - should show session summary
- [x] Test Ctrl+C during countdown - should show session summary with input working
- [x] Test session summary includes Skip/Exit keystrokes in total effort
- [x] Test scoring calculations still use only completed stages
- [x] Test data integrity: no duplicate recordings, no missing data

🤖 Generated with [Claude Code](https://claude.ai/code)