### PR TITLE
feat: enhance game display with skip functionality and pause support

### DIFF
--- a/src/game/display.rs
+++ b/src/game/display.rs
@@ -28,6 +28,7 @@ impl GameDisplay {
             comment_ranges,
             None,
             None,
+            3, // Default skip count
         )
     }
 
@@ -40,6 +41,7 @@ impl GameDisplay {
         comment_ranges: &[(usize, usize)],
         challenge: Option<&Challenge>,
         current_mistake_position: Option<usize>,
+        skips_remaining: usize,
     ) -> Result<()> {
         let mut stdout = stdout();
         let (terminal_width, terminal_height) = terminal::size()?;
@@ -59,7 +61,7 @@ impl GameDisplay {
             queue!(stdout, Print(format!("[Challenge] - Progress: {}%", progress)))?;
         }
         queue!(stdout, MoveTo(0, 1))?;
-        queue!(stdout, Print("Press ESC to quit"))?;
+        queue!(stdout, Print("Press ESC to skip challenge or Ctrl+ESC to fail"))?;
         queue!(stdout, MoveTo(0, 2))?;
         queue!(stdout, Print("─".repeat(terminal_width as usize)))?; // Separator line
         
@@ -200,10 +202,10 @@ impl GameDisplay {
         };
         
         queue!(stdout, ResetColor, Print(format!(
-            "CPM: {:.0} | WPM: {:.0} | Accuracy: {:.0}% | Mistakes: {} | Progress: {}/{}({:.0}%) | Time: {}s | Title: {} | [ESC to quit]",
+            "CPM: {:.0} | WPM: {:.0} | Accuracy: {:.0}% | Mistakes: {} | Progress: {}/{}({:.0}%) | Time: {}s | Title: {} | Skips: {} | [ESC=skip, Ctrl+ESC=fail]",
             metrics.cpm, metrics.wpm, metrics.accuracy, metrics.mistakes, 
             current_position, total_chars, progress_percent, elapsed_secs,
-            metrics.ranking_title
+            metrics.ranking_title, skips_remaining
         )))?;
         
         // Show cursor and flush all queued operations at once

--- a/src/scoring/metrics.rs
+++ b/src/scoring/metrics.rs
@@ -10,4 +10,6 @@ pub struct TypingMetrics {
     pub completion_time: Duration,
     pub challenge_score: f64,
     pub ranking_title: String,
+    pub was_skipped: bool,
+    pub was_failed: bool,
 }


### PR DESCRIPTION
## Summary
- Add skip count display in all game displays (display.rs, display_optimized.rs, display_ratatui.rs)
- Implement pause/resume functionality in scoring engine to handle time tracking correctly
- Add dialog support for skip/quit options in ratatui display with visual feedback
- Update result screen to handle skipped and failed challenges with appropriate styling
- Add session summary fail mode for better user feedback when challenges fail
- Track skipped and failed status in typing metrics for comprehensive result tracking

## Test plan
- [ ] Test skip functionality displays correctly across all display modes
- [ ] Verify pause/resume works properly with time tracking
- [ ] Test dialog interactions in ratatui mode
- [ ] Verify result screen shows appropriate messages for completed/skipped/failed challenges
- [ ] Test session summary fail mode

🤖 Generated with [Claude Code](https://claude.ai/code)