### PR TITLE
feat: add Go language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tree-sitter",
+ "tree-sitter-go",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -1066,6 +1067,16 @@ checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tree-sitter-rust = "0.20"
 tree-sitter-typescript = "0.20"
 tree-sitter-python = "0.20"
 tree-sitter-ruby = "0.20"
+tree-sitter-go = "0.20"
 crossterm = "0.27"
 ratatui = "0.26"
 rusqlite = { version = "0.29", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Features ✨
 
 - 🌳 **Tree-sitter powered**: Extracts actual functions, not random code snippets
-- 🦀🐍⚡ **Multi-language**: Rust, TypeScript, Python (more languages incoming!)  
+- 🦀🐍⚡🐹💎 **Multi-language**: Rust, TypeScript, Python, Go, Ruby (more languages incoming!)  
 - 📊 **Git stats vibes**: Track your WPM like you track your commit frequency
 - 🎯 **Actually useful**: Build muscle memory with *real* syntax patterns
 - 🔍 **Smart filtering**: Skip the `node_modules` nightmare automatically

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -280,6 +280,8 @@ Multi-layered rendering system:
 | Rust | `tree-sitter-rust` | ✅ Full support |
 | TypeScript | `tree-sitter-typescript` | ✅ Full support |
 | Python | `tree-sitter-python` | ✅ Full support |
+| Go | `tree-sitter-go` | ✅ Full support |
+| Ruby | `tree-sitter-ruby` | ✅ Full support |
 
 ---
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -7,6 +7,8 @@
 | Rust | `.rs` | ✅ Full support | `tree-sitter-rust` |
 | TypeScript | `.ts`, `.tsx` | ✅ Full support | `tree-sitter-typescript` |
 | Python | `.py` | ✅ Full support | `tree-sitter-python` |
+| Go | `.go` | ✅ Full support | `tree-sitter-go` |
+| Ruby | `.rb` | ✅ Full support | `tree-sitter-ruby` |
 
 ## Extraction Features
 
@@ -33,6 +35,20 @@
 - Decorators
 - Lambda functions
 
+### Go
+- Functions (`func`)
+- Methods (with receivers)
+- Structs (`type ... struct`)
+- Interfaces (`type ... interface`)
+- Type declarations
+
+### Ruby
+- Methods (`def`)
+- Classes (`class`)
+- Modules (`module`)
+- Instance methods
+- Class methods
+
 ## Planned Support
 
 | Language | Priority | Expected | Notes |
@@ -40,8 +56,6 @@
 | JavaScript | High | Next release | ESM/CommonJS support |
 | Swift | High | Q1 2025 | iOS/macOS development |
 | Kotlin | High | Q1 2025 | Android/JVM support |
-| Ruby | High | Q1 2025 | Rails patterns, blocks |
-| Go | Medium | Q2 2025 | Goroutines, interfaces |
 | Java | Medium | Q2 2025 | Spring Boot patterns |
 | C++ | Medium | Q3 2025 | Modern C++17/20 |
 | C# | Medium | Q3 2025 | .NET 6+ features |
@@ -57,14 +71,14 @@
 gittype --langs rust
 
 # Multiple languages
-gittype --langs rust,typescript,python
+gittype --langs rust,typescript,python,go,ruby
 ```
 
 ### Configuration File
 
 ```toml
 [default]
-langs = ["rust", "typescript"]
+langs = ["rust", "typescript", "python", "go", "ruby"]
 ```
 
 ## Code Extraction Quality

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -26,6 +26,8 @@ impl Default for Config {
                     "rust".to_string(),
                     "typescript".to_string(),
                     "python".to_string(),
+                    "go".to_string(),
+                    "ruby".to_string(),
                 ],
                 max_lines: 40,
                 include: vec!["src/**".to_string()],

--- a/src/extractor/challenge_converter.rs
+++ b/src/extractor/challenge_converter.rs
@@ -346,6 +346,7 @@ impl ChallengeConverter {
             super::Language::TypeScript => "typescript".to_string(),
             super::Language::Python => "python".to_string(),
             super::Language::Ruby => "ruby".to_string(),
+            super::Language::Go => "go".to_string(),
         }
     }
 }

--- a/src/extractor/challenge_converter.rs
+++ b/src/extractor/challenge_converter.rs
@@ -105,6 +105,8 @@ impl ChallengeConverter {
             Some("rs") => "rust".to_string(),
             Some("ts") | Some("tsx") => "typescript".to_string(),
             Some("py") => "python".to_string(),
+            Some("go") => "go".to_string(),
+            Some("rb") => "ruby".to_string(),
             Some("js") | Some("jsx") => "javascript".to_string(),
             _ => "text".to_string(),
         }

--- a/src/extractor/chunk.rs
+++ b/src/extractor/chunk.rs
@@ -7,6 +7,7 @@ pub enum ChunkType {
     Class,
     Method,
     Struct,
+    Interface,
     Module,
 }
 

--- a/src/extractor/language.rs
+++ b/src/extractor/language.rs
@@ -4,6 +4,7 @@ pub enum Language {
     TypeScript,
     Python,
     Ruby,
+    Go,
 }
 
 impl Language {
@@ -13,6 +14,7 @@ impl Language {
             "ts" | "tsx" => Some(Language::TypeScript),
             "py" => Some(Language::Python),
             "rb" => Some(Language::Ruby),
+            "go" => Some(Language::Go),
             _ => None,
         }
     }
@@ -23,6 +25,7 @@ impl Language {
             Language::TypeScript => "ts",
             Language::Python => "py",
             Language::Ruby => "rb",
+            Language::Go => "go",
         }
     }
 }

--- a/src/extractor/parser.rs
+++ b/src/extractor/parser.rs
@@ -88,10 +88,7 @@ impl CodeExtractor {
                 parser
                     .set_language(tree_sitter_go::language())
                     .map_err(|e| {
-                        GitTypeError::ExtractionFailed(format!(
-                            "Failed to set Go language: {}",
-                            e
-                        ))
+                        GitTypeError::ExtractionFailed(format!("Failed to set Go language: {}", e))
                     })?;
             }
         }

--- a/src/extractor/parser.rs
+++ b/src/extractor/parser.rs
@@ -22,6 +22,7 @@ impl Default for ExtractionOptions {
                 "**/*.tsx".to_string(),
                 "**/*.py".to_string(),
                 "**/*.rb".to_string(),
+                "**/*.go".to_string(),
             ],
             exclude_patterns: vec![
                 "**/target/**".to_string(),
@@ -79,6 +80,16 @@ impl CodeExtractor {
                     .map_err(|e| {
                         GitTypeError::ExtractionFailed(format!(
                             "Failed to set Ruby language: {}",
+                            e
+                        ))
+                    })?;
+            }
+            Language::Go => {
+                parser
+                    .set_language(tree_sitter_go::language())
+                    .map_err(|e| {
+                        GitTypeError::ExtractionFailed(format!(
+                            "Failed to set Go language: {}",
                             e
                         ))
                     })?;
@@ -269,6 +280,12 @@ impl CodeExtractor {
                 (class name: (constant) @name) @class
                 (module name: (constant) @name) @module
             ",
+            Language::Go => "
+                (function_declaration name: (identifier) @name) @function
+                (method_declaration receiver: _ name: (field_identifier) @name) @method
+                (type_spec name: (type_identifier) @name type: (struct_type)) @struct
+                (type_spec name: (type_identifier) @name type: (interface_type)) @interface
+            ",
         };
 
         let query = Query::new(tree.language(), query_str).map_err(|e| {
@@ -351,6 +368,7 @@ impl CodeExtractor {
             "method" => ChunkType::Method,
             "class" | "impl" => ChunkType::Class,
             "struct" => ChunkType::Struct,
+            "interface" => ChunkType::Interface,
             "module" => ChunkType::Module,
             "arrow_function" => ChunkType::Function,
             "function_expression" => ChunkType::Function,
@@ -420,6 +438,7 @@ impl CodeExtractor {
                 if child.kind() == "identifier"
                     || child.kind() == "type_identifier"
                     || child.kind() == "property_identifier"
+                    || child.kind() == "field_identifier"
                     || child.kind() == "constant"
                 {
                     let start = child.start_byte();
@@ -566,6 +585,7 @@ impl CodeExtractor {
             Language::TypeScript => "(comment) @comment",
             Language::Python => "(comment) @comment",
             Language::Ruby => "(comment) @comment",
+            Language::Go => "(comment) @comment",
         };
 
         let query = match Query::new(tree.language(), comment_query) {
@@ -589,6 +609,7 @@ impl CodeExtractor {
                     Language::TypeScript => node_kind == "comment",
                     Language::Python => node_kind == "comment",
                     Language::Ruby => node_kind == "comment",
+                    Language::Go => node_kind == "comment",
                 };
 
                 if !is_valid_comment {

--- a/tests/extractor_unit_tests.rs
+++ b/tests/extractor_unit_tests.rs
@@ -25,6 +25,7 @@ fn test_language_from_extension() {
     assert_eq!(Language::from_extension("tsx"), Some(Language::TypeScript));
     assert_eq!(Language::from_extension("py"), Some(Language::Python));
     assert_eq!(Language::from_extension("rb"), Some(Language::Ruby));
+    assert_eq!(Language::from_extension("go"), Some(Language::Go));
     assert_eq!(Language::from_extension("unknown"), None);
 }
 
@@ -454,4 +455,157 @@ end
     let method_names: Vec<&String> = method_chunks.iter().map(|c| &c.name).collect();
     assert!(method_names.contains(&&"login".to_string()));
     assert!(method_names.contains(&&"logout".to_string()));
+}
+
+#[test]
+fn test_go_function_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.go");
+
+    let go_code = r#"package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, world!")
+}
+
+func add(a, b int) int {
+    return a + b
+}
+
+func multiply(x int, y int) int {
+    return x * y
+}
+"#;
+    fs::write(&file_path, go_code).unwrap();
+
+    let mut extractor = CodeExtractor::new().unwrap();
+    let chunks = extractor
+        .extract_chunks(temp_dir.path(), ExtractionOptions::default())
+        .unwrap();
+
+    assert_eq!(chunks.len(), 3);
+    
+    let function_names: Vec<&String> = chunks.iter().map(|c| &c.name).collect();
+    assert!(function_names.contains(&&"main".to_string()));
+    assert!(function_names.contains(&&"add".to_string()));
+    assert!(function_names.contains(&&"multiply".to_string()));
+    
+    for chunk in &chunks {
+        assert!(matches!(chunk.chunk_type, ChunkType::Function));
+        assert_eq!(chunk.language, Language::Go);
+    }
+}
+
+#[test]
+fn test_go_struct_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.go");
+
+    let go_code = r#"package main
+
+type Person struct {
+    Name string
+    Age  int
+}
+
+type Address struct {
+    Street string
+    City   string
+    Zip    string
+}
+
+func (p Person) GetName() string {
+    return p.Name
+}
+
+func (a *Address) GetFullAddress() string {
+    return a.Street + ", " + a.City + " " + a.Zip
+}
+"#;
+    fs::write(&file_path, go_code).unwrap();
+
+    let mut extractor = CodeExtractor::new().unwrap();
+    let chunks = extractor
+        .extract_chunks(temp_dir.path(), ExtractionOptions::default())
+        .unwrap();
+
+    assert_eq!(chunks.len(), 4); // 2 structs + 2 methods
+
+    // Find struct chunks
+    let struct_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.chunk_type, ChunkType::Struct))
+        .collect();
+    assert_eq!(struct_chunks.len(), 2);
+
+    let struct_names: Vec<&String> = struct_chunks.iter().map(|c| &c.name).collect();
+    assert!(struct_names.contains(&&"Person".to_string()));
+    assert!(struct_names.contains(&&"Address".to_string()));
+
+    // Find method chunks
+    let method_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.chunk_type, ChunkType::Method))
+        .collect();
+    assert_eq!(method_chunks.len(), 2);
+
+    let method_names: Vec<&String> = method_chunks.iter().map(|c| &c.name).collect();
+    assert!(method_names.contains(&&"GetName".to_string()));
+    assert!(method_names.contains(&&"GetFullAddress".to_string()));
+}
+
+#[test]
+fn test_go_interface_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.go");
+
+    let go_code = r#"package main
+
+type Writer interface {
+    Write([]byte) (int, error)
+}
+
+type Reader interface {
+    Read([]byte) (int, error)
+}
+
+type ReadWriter interface {
+    Reader
+    Writer
+}
+
+func process(rw ReadWriter) {
+    // Implementation here
+}
+"#;
+    fs::write(&file_path, go_code).unwrap();
+
+    let mut extractor = CodeExtractor::new().unwrap();
+    let chunks = extractor
+        .extract_chunks(temp_dir.path(), ExtractionOptions::default())
+        .unwrap();
+
+    assert_eq!(chunks.len(), 4); // 3 interfaces + 1 function
+
+    // Find interface chunks
+    let interface_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.chunk_type, ChunkType::Interface))
+        .collect();
+    assert_eq!(interface_chunks.len(), 3);
+
+    let interface_names: Vec<&String> = interface_chunks.iter().map(|c| &c.name).collect();
+    assert!(interface_names.contains(&&"Writer".to_string()));
+    assert!(interface_names.contains(&&"Reader".to_string()));
+    assert!(interface_names.contains(&&"ReadWriter".to_string()));
+
+    // Find function chunk
+    let function_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.chunk_type, ChunkType::Function))
+        .collect();
+    assert_eq!(function_chunks.len(), 1);
+    assert_eq!(function_chunks[0].name, "process");
 }

--- a/tests/extractor_unit_tests.rs
+++ b/tests/extractor_unit_tests.rs
@@ -486,12 +486,12 @@ func multiply(x int, y int) int {
         .unwrap();
 
     assert_eq!(chunks.len(), 3);
-    
+
     let function_names: Vec<&String> = chunks.iter().map(|c| &c.name).collect();
     assert!(function_names.contains(&&"main".to_string()));
     assert!(function_names.contains(&&"add".to_string()));
     assert!(function_names.contains(&&"multiply".to_string()));
-    
+
     for chunk in &chunks {
         assert!(matches!(chunk.chunk_type, ChunkType::Function));
         assert_eq!(chunk.language, Language::Go);


### PR DESCRIPTION
## Summary
- Add comprehensive Go language support to gittype
- Complete implementation of issue #55
- Update all documentation to reflect Go and Ruby support

## Changes Made

### Core Implementation
- Added `tree-sitter-go` dependency for Go AST parsing
- Extended Language enum to include Go
- Implemented Go-specific code extraction for:
  - Functions (`func` declarations)
  - Methods (with receiver syntax)
  - Structs (`type` declarations with `struct_type`)
  - Interfaces (`type` declarations with `interface_type`)
- Added Go file extension mapping (`.go` files)
- Enhanced name extraction to support `field_identifier` nodes
- Added `Interface` chunk type for Go interfaces

### Documentation Updates
- Updated README.md with Go (🐹) and Ruby (💎) emoji support
- Updated `docs/supported-languages.md`:
  - Added Go and Ruby to current support table
  - Added detailed extraction features for both languages
  - Updated examples to include Go and Ruby
- Updated `docs/ARCHITECTURE.md` with Go and Ruby support
- Updated default configuration to include Go and Ruby

### Testing
- Added comprehensive test coverage for Go language features:
  - Function extraction test
  - Struct and method extraction test
  - Interface extraction test
- All existing tests continue to pass

## Test Plan
- [x] Compile successfully
- [x] All existing tests pass
- [x] New Go extraction tests pass
- [x] Documentation is consistent and up-to-date

## Breaking Changes
None. This is a pure addition that maintains backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)