### PR TITLE
feat: remove --max-lines option completely

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,7 +72,6 @@ Language-specific extraction is handled through the `Language` enum and associat
 pub struct Config {
     pub repo_path: PathBuf,
     pub languages: Vec<Language>,
-    pub max_lines: usize,
     pub stages: usize,
     // ...
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -252,7 +252,6 @@ Examples:
 pub fn extract_chunks(
     file_path: &Path,
     language: Language,
-    max_lines: usize,
 ) -> Result<Vec<CodeChunk>, ExtractionError> {
     let content = std::fs::read_to_string(file_path)
         .map_err(|e| ExtractionError::FileRead(e))?;
@@ -261,7 +260,7 @@ pub fn extract_chunks(
     let tree = parser.parse(&content, None)
         .ok_or(ExtractionError::ParseFailed)?;
     
-    extract_from_tree(&tree, &content, max_lines)
+    extract_from_tree(&tree, &content)
 }
 ```
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -96,7 +96,6 @@ langs = ["rust", "typescript", "python", "go", "ruby"]
 - **Comments Only**: Blocks with only comments
 - **Import Statements**: Standalone import/use declarations
 - **Very Short Code**: Code blocks under minimum threshold
-- **Very Long Code**: Code blocks exceeding `--max-lines`
 
 ## Adding New Language Support
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -7,7 +7,6 @@ pub struct Config {
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct ExtractionConfig {
     pub languages: Vec<String>,
-    pub max_lines: usize,
     pub include: Vec<String>,
     pub exclude: Vec<String>,
 }
@@ -29,7 +28,6 @@ impl Default for Config {
                     "go".to_string(),
                     "ruby".to_string(),
                 ],
-                max_lines: 40,
                 include: vec!["src/**".to_string()],
                 exclude: vec!["target/**".to_string(), "node_modules/**".to_string()],
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,6 @@ struct Cli {
     #[arg(long, default_value_t = 3)]
     stages: usize,
 
-    /// Maximum lines per challenge
-    #[arg(long, default_value_t = 40)]
-    max_lines: usize,
 
     /// Glob patterns for files to include
     #[arg(long)]
@@ -99,7 +96,6 @@ fn main() -> anyhow::Result<()> {
                     options.exclude_patterns = exclude_patterns;
                 }
 
-                options.max_lines = Some(cli.max_lines);
 
                 // Show loading screen during startup
                 let loading_screen = match LoadingScreen::new() {

--- a/tests/extractor_unit_tests.rs
+++ b/tests/extractor_unit_tests.rs
@@ -15,7 +15,6 @@ fn test_extraction_options_default() {
     assert!(options
         .exclude_patterns
         .contains(&"**/target/**".to_string()));
-    assert_eq!(options.max_lines, None);
 }
 
 #[test]
@@ -91,37 +90,6 @@ pub struct Config {
     assert!(matches!(chunks[0].chunk_type, ChunkType::Struct));
 }
 
-#[test]
-fn test_max_lines_filtering() {
-    let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("test.rs");
-
-    let rust_code = r#"
-fn small_function() {
-    println!("small");
-}
-
-fn large_function() {
-    println!("line 1");
-    println!("line 2");
-    println!("line 3");
-    println!("line 4");
-    println!("line 5");
-}
-"#;
-    fs::write(&file_path, rust_code).unwrap();
-
-    let mut extractor = CodeExtractor::new().unwrap();
-    let options = ExtractionOptions {
-        max_lines: Some(3),
-        ..Default::default()
-    };
-
-    let chunks = extractor.extract_chunks(temp_dir.path(), options).unwrap();
-
-    assert_eq!(chunks.len(), 1);
-    assert_eq!(chunks[0].name, "small_function");
-}
 
 #[test]
 fn test_gitignore_respected() {


### PR DESCRIPTION
## Summary
- Remove the --max-lines CLI option and related functionality 
- Simplify the codebase by allowing all code chunks regardless of length
- Remove line count filtering logic from code extraction

## Changes
- Remove --max-lines argument from CLI interface
- Remove max_lines field from ExtractionOptions and Config structs  
- Remove line count filtering logic in parser.rs
- Remove related test cases and documentation references

## Test plan
- [x] All existing tests pass
- [x] Code compiles without warnings
- [x] No references to max_lines remain in codebase

🤖 Generated with [Claude Code](https://claude.ai/code)