### PR TITLE
feat: use current directory as default repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ cargo install gittype
 # cd into your messy codebase
 cd ~/that-project-you-never-finished
 
-# Start typing your own spaghetti code
+# Start typing your own spaghetti code (uses current directory by default)
 gittype
+
+# Or specify a specific repository path
+gittype /path/to/another/repo
 ```
 
 ## Demo 🎮

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@
    cd /path/to/your/project
    ```
 
-2. **Start typing practice:**
+2. **Start typing practice (uses current directory by default):**
    ```bash
    gittype
    ```
@@ -22,6 +22,8 @@
 ```bash
 gittype [OPTIONS] [REPO_PATH] [COMMAND]
 ```
+
+**Note:** `REPO_PATH` is optional and defaults to the current directory (`.`) if not specified.
 
 ### Basic Options
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,8 @@ fn main() -> anyhow::Result<()> {
             // TODO: Implement export functionality
         }
         None => {
-            if let Some(repo_path) = cli.repo_path {
+            let repo_path = cli.repo_path.unwrap_or_else(|| PathBuf::from("."));
+            {
                 // Build extraction options from CLI arguments
                 let mut options = ExtractionOptions::default();
 
@@ -164,8 +165,6 @@ fn main() -> anyhow::Result<()> {
                         }
                     }
                 }
-            } else {
-                println!("Please specify a repository path or use --help for usage information");
             }
         }
     }


### PR DESCRIPTION
## Summary

- CLI now defaults to current directory when no `REPO_PATH` is specified
- Users can now simply run `gittype` without arguments to start typing practice in the current repository
- Removes the error message for missing repository path argument
- Updates documentation to reflect the new default behavior

## Changes

- **src/main.rs**: Modified CLI argument handling to use current directory (`.`) as default
- **README.md**: Updated Quick Start section to clarify default behavior
- **docs/usage.md**: Added note about optional REPO_PATH and updated examples

## Test plan

- [ ] Verify `gittype` runs without arguments in a git repository
- [ ] Verify `gittype /path/to/repo` still works with explicit path
- [ ] Check that documentation accurately reflects the new behavior

🤖 Generated with [Claude Code](https://claude.ai/code)