### PR TITLE
fix: improve terminal cleanup to prevent utf character output in iTerm2

### DIFF
--- a/src/game/display_ratatui.rs
+++ b/src/game/display_ratatui.rs
@@ -353,11 +353,11 @@ impl GameDisplayRatatui {
         execute!(stdout, crossterm::terminal::Clear(ClearType::All))?;
         execute!(stdout, MoveTo(0, 0))?;
         execute!(stdout, crossterm::style::ResetColor)?;
-        
+
         // Ensure alternate screen is exited and cursor is restored
         execute!(stdout, crossterm::terminal::LeaveAlternateScreen)?;
         execute!(stdout, crossterm::cursor::Show)?;
-        
+
         stdout.flush()?;
 
         Ok(())

--- a/src/game/display_ratatui.rs
+++ b/src/game/display_ratatui.rs
@@ -353,6 +353,11 @@ impl GameDisplayRatatui {
         execute!(stdout, crossterm::terminal::Clear(ClearType::All))?;
         execute!(stdout, MoveTo(0, 0))?;
         execute!(stdout, crossterm::style::ResetColor)?;
+        
+        // Ensure alternate screen is exited and cursor is restored
+        execute!(stdout, crossterm::terminal::LeaveAlternateScreen)?;
+        execute!(stdout, crossterm::cursor::Show)?;
+        
         stdout.flush()?;
 
         Ok(())

--- a/src/game/screens/result_screen.rs
+++ b/src/game/screens/result_screen.rs
@@ -569,6 +569,7 @@ impl ResultScreen {
                         KeyCode::Char('c')
                             if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
                         {
+                            crate::game::stage_manager::cleanup_terminal();
                             std::process::exit(0);
                         }
                         _ => continue,
@@ -757,6 +758,7 @@ impl ResultScreen {
                         KeyCode::Char('c')
                             if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
                         {
+                            crate::game::stage_manager::cleanup_terminal();
                             std::process::exit(0);
                         }
                         _ => continue,

--- a/src/game/stage_manager.rs
+++ b/src/game/stage_manager.rs
@@ -457,12 +457,12 @@ impl StageManager {
 // Comprehensive terminal cleanup function
 pub fn cleanup_terminal() {
     use crossterm::{execute, terminal};
-    
+
     // Disable raw mode
     if let Err(e) = terminal::disable_raw_mode() {
         eprintln!("Warning: Failed to disable raw mode: {}", e);
     }
-    
+
     // Exit alternate screen and restore cursor
     let _ = execute!(
         std::io::stdout(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use clap::{Parser, Subcommand};
 use gittype::extractor::{ExtractionOptions, ProgressReporter, RepositoryLoader};
 use gittype::game::screens::loading_screen::LoadingScreen;
-use gittype::game::{stage_manager::{show_session_summary_on_interrupt, cleanup_terminal}, StageManager};
+use gittype::game::{
+    stage_manager::{cleanup_terminal, show_session_summary_on_interrupt},
+    StageManager,
+};
 use std::path::PathBuf;
 
 #[derive(Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use gittype::extractor::{ExtractionOptions, ProgressReporter, RepositoryLoader};
 use gittype::game::screens::loading_screen::LoadingScreen;
-use gittype::game::{stage_manager::show_session_summary_on_interrupt, StageManager};
+use gittype::game::{stage_manager::{show_session_summary_on_interrupt, cleanup_terminal}, StageManager};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -57,6 +57,11 @@ enum Commands {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Set up panic hook to ensure terminal cleanup
+    std::panic::set_hook(Box::new(|_| {
+        cleanup_terminal();
+    }));
+
     // Set up Ctrl+C handler
     ctrlc::set_handler(move || {
         show_session_summary_on_interrupt();


### PR DESCRIPTION
## Summary
- Improve terminal cleanup process to prevent UTF character output issues in iTerm2
- Fix terminal state restoration to avoid garbled output when exiting the application

## Changes
- Enhanced terminal cleanup logic to properly restore terminal state
- Prevents unwanted UTF character artifacts from appearing in iTerm2 after program exit

## Test plan
- Test application exit in iTerm2 terminal
- Verify no garbled characters appear after program termination
- Test on various terminal emulators for compatibility