### PR TITLE
fix(terminal): pop keyboard enhancement flags on cleanup to avoid iTerm2 st
uck state

### DIFF
--- a/src/game/stage_manager.rs
+++ b/src/game/stage_manager.rs
@@ -456,13 +456,17 @@ impl StageManager {
 
 // Comprehensive terminal cleanup function
 pub fn cleanup_terminal() {
-    use crossterm::{execute, terminal};
+    use crossterm::{event::PopKeyboardEnhancementFlags, execute, terminal};
     use std::io::{stdout, Write};
 
     // Disable raw mode first
     if let Err(e) = terminal::disable_raw_mode() {
         eprintln!("Warning: Failed to disable raw mode: {}", e);
     }
+
+    // Pop keyboard enhancement flags to avoid leaving terminal in special key-report mode
+    // This is especially important for iTerm2 which keeps modes until explicitly reverted
+    let _ = execute!(stdout(), PopKeyboardEnhancementFlags);
 
     // Exit alternate screen and restore cursor with explicit error handling
     if let Err(e) = execute!(


### PR DESCRIPTION
Summary
- Ensure terminal state is fully restored on exit, specifically for iTerm2 where
 keyboard enhancement modes persist unless explicitly popped.

What/Why
- We push Keyboard Enhancement Flags (DISAMBIGUATE_ESCAPE_CODES, REPORT_ALL_KEYS
_AS_ESCAPE_CODES, REPORT_ALTERNATE_KEYS) to improve key handling.
- On some terminals (notably iTerm2), if these flags are left enabled at process
 exit, the shell stays in a mode where raw/unicode key codes are printed and Ctr
l+C may not behave as expected.
- Add PopKeyboardEnhancementFlags in cleanup_terminal() so every exit path rever
ts the enhancement flags in addition to disabling raw mode.

Changes
- src/game/stage_manager.rs
  - Add PopKeyboardEnhancementFlags to cleanup_terminal() before leaving the alt
ernate screen and restoring cursor/colors.

Testing
- Run app in iTerm2 with Terminal State features enabled (Disambiguate Escape Co
des / Report Alternate Keys / Report All Keys as Escape Codes):
  - Start app, exit via various paths (ESC -> exit, Ctrl+C handler, normal quit,
 panic hook).
  - Confirm shell returns to normal: no raw unicode/escape sequences, Ctrl+C wor
ks.

Notes
- This keeps the app safe even if iTerm2 has those options enabled. Users can st
ill disable them to be extra safe.