### PR TITLE
feat: update Homebrew to use prebuilt binaries and add ARM64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: x86_64-apple-darwin
@@ -193,17 +195,46 @@ jobs:
       
       - name: Update Homebrew formula
         run: |
-          # Calculate the SHA256 of the source tarball
-          TARBALL_URL="https://github.com/unhappychoice/gittype/archive/${{ needs.release.outputs.new_version }}.tar.gz"
-          SHA256=$(curl -sL "$TARBALL_URL" | sha256sum | cut -d' ' -f1)
+          # Calculate SHA256 for each binary release
+          VERSION=${{ needs.release.outputs.new_version }}
           
-          # Update the formula
-          sed -i "s|url \".*\"|url \"$TARBALL_URL\"|" homebrew-tap/Formula/gittype.rb
-          sed -i "s|sha256 \".*\"|sha256 \"$SHA256\"|" homebrew-tap/Formula/gittype.rb
+          # macOS Intel
+          MACOS_INTEL_URL="https://github.com/unhappychoice/gittype/releases/download/$VERSION/gittype-$VERSION-x86_64-apple-darwin.tar.gz"
+          MACOS_INTEL_SHA=$(curl -sL "$MACOS_INTEL_URL" | sha256sum | cut -d' ' -f1)
           
+          # macOS ARM
+          MACOS_ARM_URL="https://github.com/unhappychoice/gittype/releases/download/$VERSION/gittype-$VERSION-aarch64-apple-darwin.tar.gz"
+          MACOS_ARM_SHA=$(curl -sL "$MACOS_ARM_URL" | sha256sum | cut -d' ' -f1)
+          
+          # Linux Intel
+          LINUX_INTEL_URL="https://github.com/unhappychoice/gittype/releases/download/$VERSION/gittype-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
+          LINUX_INTEL_SHA=$(curl -sL "$LINUX_INTEL_URL" | sha256sum | cut -d' ' -f1)
+          
+          # Linux ARM64
+          LINUX_ARM_URL="https://github.com/unhappychoice/gittype/releases/download/$VERSION/gittype-$VERSION-aarch64-unknown-linux-gnu.tar.gz"
+          LINUX_ARM_SHA=$(curl -sL "$LINUX_ARM_URL" | sha256sum | cut -d' ' -f1)
+          
+          # Update the formula with new URLs and SHA256s
           cd homebrew-tap
+          
+          # Update macOS Intel
+          sed -i "/on_macos do/,/on_intel do/,/end/ s|url \".*\"|url \"$MACOS_INTEL_URL\"|" Formula/gittype.rb
+          sed -i "/on_macos do/,/on_intel do/,/end/ s|sha256 \".*\"|sha256 \"$MACOS_INTEL_SHA\"|" Formula/gittype.rb
+          
+          # Update macOS ARM  
+          sed -i "/on_macos do/,/on_arm do/,/end/ s|url \".*\"|url \"$MACOS_ARM_URL\"|" Formula/gittype.rb
+          sed -i "/on_macos do/,/on_arm do/,/end/ s|sha256 \".*\"|sha256 \"$MACOS_ARM_SHA\"|" Formula/gittype.rb
+          
+          # Update Linux Intel
+          sed -i "/on_linux do/,/on_intel do/,/end/ s|url \".*\"|url \"$LINUX_INTEL_URL\"|" Formula/gittype.rb
+          sed -i "/on_linux do/,/on_intel do/,/end/ s|sha256 \".*\"|sha256 \"$LINUX_INTEL_SHA\"|" Formula/gittype.rb
+          
+          # Update Linux ARM
+          sed -i "/on_linux do/,/on_arm do/,/end/ s|url \".*\"|url \"$LINUX_ARM_URL\"|" Formula/gittype.rb
+          sed -i "/on_linux do/,/on_arm do/,/end/ s|sha256 \".*\"|sha256 \"$LINUX_ARM_SHA\"|" Formula/gittype.rb
+          
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add Formula/gittype.rb
-          git commit -m "chore: update gittype to ${{ needs.release.outputs.new_version }}"
+          git commit -m "chore: update gittype to $VERSION"
           git push


### PR DESCRIPTION
## Summary
- Update Homebrew formula to use prebuilt binaries instead of `cargo install`
- Add Linux ARM64 (`aarch64-unknown-linux-gnu`) support for M1/M2 Mac compatibility
- Update GitHub Actions release workflow to handle multi-architecture binary distribution

## Benefits
- **Faster installation**: No more Rust compilation required
- **No dependencies**: Users don't need Rust toolchain installed
- **Better M1/M2 support**: Works in Docker, VMs, and native Linux on Apple Silicon
- **Broader compatibility**: Covers 5 architectures total

## Architecture Support
- ✅ Linux Intel/AMD (`x86_64-unknown-linux-gnu`) - includes WSL
- ✅ Linux ARM64 (`aarch64-unknown-linux-gnu`) - M1/M2 Docker/VM, Raspberry Pi, AWS Graviton
- ✅ Windows Intel/AMD (`x86_64-pc-windows-msvc`)
- ✅ macOS Intel (`x86_64-apple-darwin`)
- ✅ macOS Apple Silicon (`aarch64-apple-darwin`)

## Changes
### GitHub Actions (`release.yml`)
- Added `aarch64-unknown-linux-gnu` to build matrix
- Updated Homebrew formula update logic to handle platform-specific binaries
- Calculate SHA256 for each architecture's binary release

### Homebrew Formula (already updated in tap repo)
- Converted from source-based to binary-based distribution
- Added platform detection for optimal binary selection
- Removed Rust build dependency

## Test Plan
- [x] Verified build matrix includes all 5 targets
- [x] Updated Homebrew formula structure for binary distribution
- [x] Confirmed release workflow handles multi-architecture SHA256 calculation
- [ ] Test with next release to verify end-to-end functionality

🤖 Generated with [Claude Code](https://claude.ai/code)