### PR TITLE
chore: Update Twitter references to X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,7 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Go language support ([1baa6fc](https://github.com/unhappychoice/gittype/commit/1baa6fc))
 - feat: add Ruby language support ([aa293da](https://github.com/unhappychoice/gittype/commit/aa293da))
 - feat: improve typing screen UI/UX ([f89e6e8](https://github.com/unhappychoice/gittype/commit/f89e6e8))
-- feat: add info dialog with GitHub and Twitter links ([9d3a407](https://github.com/unhappychoice/gittype/commit/9d3a407))
+- feat: add info dialog with GitHub and X links ([9d3a407](https://github.com/unhappychoice/gittype/commit/9d3a407))
 - feat: enhance exit summary screen with session-based sharing ([86fced3](https://github.com/unhappychoice/gittype/commit/86fced3))
 - feat: add comprehensive SNS sharing functionality ([5f110b1](https://github.com/unhappychoice/gittype/commit/5f110b1))
 - feat: improve progress reporting for parallel AST parsing ([614b0ac](https://github.com/unhappychoice/gittype/commit/614b0ac))

--- a/src/game/screens/exit_summary_screen.rs
+++ b/src/game/screens/exit_summary_screen.rs
@@ -365,10 +365,7 @@ impl ExitSummaryScreen {
                 if let Event::Key(key_event) = event::read()? {
                     match key_event.code {
                         KeyCode::Char('1') => {
-                            let _ = Self::share_session_result(
-                                session_summary,
-                                SharingPlatform::Twitter,
-                            );
+                            let _ = Self::share_session_result(session_summary, SharingPlatform::X);
                             break;
                         }
                         KeyCode::Char('2') => {
@@ -426,9 +423,9 @@ impl ExitSummaryScreen {
         session_summary: &SessionSummary,
     ) -> String {
         match platform {
-            SharingPlatform::Twitter => {
+            SharingPlatform::X => {
                 format!(
-                    "https://twitter.com/intent/tweet?text={}",
+                    "https://x.com/intent/tweet?text={}",
                     urlencoding::encode(text)
                 )
             }

--- a/src/game/screens/info_dialog.rs
+++ b/src/game/screens/info_dialog.rs
@@ -10,7 +10,7 @@ use std::io::{stdout, Write};
 
 pub enum InfoAction {
     OpenGithub,
-    OpenTwitter,
+    OpenX,
     Close,
 }
 
@@ -21,7 +21,7 @@ impl InfoDialog {
         let mut selected_option = 0;
         let options = [
             ("GitHub Repository", InfoAction::OpenGithub),
-            ("Twitter #gittype", InfoAction::OpenTwitter),
+            ("X #gittype", InfoAction::OpenX),
             ("Close", InfoAction::Close),
         ];
 
@@ -48,7 +48,7 @@ impl InfoDialog {
                         KeyCode::Char(' ') => {
                             return Ok(match selected_option {
                                 0 => InfoAction::OpenGithub,
-                                1 => InfoAction::OpenTwitter,
+                                1 => InfoAction::OpenX,
                                 _ => InfoAction::Close,
                             });
                         }
@@ -80,7 +80,7 @@ impl InfoDialog {
                         }
                         KeyCode::Esc | KeyCode::Char('q') => return Ok(InfoAction::Close),
                         KeyCode::Char('g') => return Ok(InfoAction::OpenGithub),
-                        KeyCode::Char('t') => return Ok(InfoAction::OpenTwitter),
+                        KeyCode::Char('x') => return Ok(InfoAction::OpenX),
                         _ => {}
                     }
                 }
@@ -193,10 +193,10 @@ impl InfoDialog {
         Ok(())
     }
 
-    pub fn open_twitter() -> Result<()> {
-        let url = "https://twitter.com/search?q=%23gittype";
+    pub fn open_x() -> Result<()> {
+        let url = "https://x.com/search?q=%23gittype";
         if open::that(url).is_err() {
-            Self::show_url_fallback("Twitter Search", url)?;
+            Self::show_url_fallback("X Search", url)?;
         }
         Ok(())
     }

--- a/src/game/screens/result_screen.rs
+++ b/src/game/screens/result_screen.rs
@@ -759,7 +759,7 @@ impl ResultScreen {
                 if let Event::Key(key_event) = event::read()? {
                     match key_event.code {
                         KeyCode::Char('1') => {
-                            let _ = SharingService::share_result(metrics, SharingPlatform::Twitter);
+                            let _ = SharingService::share_result(metrics, SharingPlatform::X);
                             break;
                         }
                         KeyCode::Char('2') => {

--- a/src/game/screens/title_screen.rs
+++ b/src/game/screens/title_screen.rs
@@ -296,8 +296,8 @@ impl TitleScreen {
             InfoAction::OpenGithub => {
                 InfoDialog::open_github()?;
             }
-            InfoAction::OpenTwitter => {
-                InfoDialog::open_twitter()?;
+            InfoAction::OpenX => {
+                InfoDialog::open_x()?;
             }
             InfoAction::Close => {
                 // Do nothing, just close the dialog

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -4,7 +4,7 @@ use crossterm::event::KeyCode;
 
 #[derive(Debug, Clone)]
 pub enum SharingPlatform {
-    Twitter,
+    X,
     Reddit,
     LinkedIn,
     Facebook,
@@ -13,7 +13,7 @@ pub enum SharingPlatform {
 impl SharingPlatform {
     pub fn name(&self) -> &'static str {
         match self {
-            Self::Twitter => "Twitter",
+            Self::X => "X",
             Self::Reddit => "Reddit",
             Self::LinkedIn => "LinkedIn",
             Self::Facebook => "Facebook",
@@ -21,7 +21,7 @@ impl SharingPlatform {
     }
 
     pub fn all() -> Vec<Self> {
-        vec![Self::Twitter, Self::Reddit, Self::LinkedIn, Self::Facebook]
+        vec![Self::X, Self::Reddit, Self::LinkedIn, Self::Facebook]
     }
 }
 
@@ -47,9 +47,9 @@ impl SharingService {
         let text = Self::create_share_text(metrics);
 
         match platform {
-            SharingPlatform::Twitter => {
+            SharingPlatform::X => {
                 format!(
-                    "https://twitter.com/intent/tweet?text={}",
+                    "https://x.com/intent/tweet?text={}",
                     urlencoding::encode(&text)
                 )
             }


### PR DESCRIPTION
closes: #121

## Summary
Update all references to "Twitter" in the codebase and documentation to reflect the platform's rebrand to "X".

## Changes Made
- **SharingPlatform enum**: Updated `Twitter` to `X`
- **Sharing URLs**: Changed from `twitter.com` to `x.com`
- **Info dialog**: Updated platform references and keybindings (`t` → `x`)
- **CHANGELOG.md**: Updated historical reference to reflect current branding
- **UI text**: All user-facing references now use "X"

## Files Updated
- `src/sharing.rs` - Core sharing platform enum and URL generation
- `src/game/screens/info_dialog.rs` - Dialog interface and keybindings
- `src/game/screens/title_screen.rs` - Info action handling
- `src/game/screens/exit_summary_screen.rs` - Session sharing functionality
- `src/game/screens/result_screen.rs` - Result sharing functionality
- `CHANGELOG.md` - Historical reference update

## Testing
- ✅ All tests pass
- ✅ Code compiles without warnings
- ✅ Clippy checks pass
- ✅ Code formatted with rustfmt

## Benefits
- **Current Branding**: Reflects the platform's current identity
- **Professional Appearance**: Shows attention to detail and current awareness
- **User Clarity**: Avoids confusion about platform references
- **Consistency**: Maintains uniform branding throughout the project

🤖 Generated with [Claude Code](https://claude.ai/code)