### PR TITLE
feat: Color-code session score display based on ranking tier

### DIFF
--- a/src/game/screens/result_screen.rs
+++ b/src/game/screens/result_screen.rs
@@ -1,6 +1,6 @@
 use crate::game::ascii_digits::get_digit_patterns;
 use crate::game::ascii_rank_titles_generated::get_rank_title_display;
-use crate::scoring::{ScoringEngine, TypingMetrics};
+use crate::scoring::{RankingTitle, ScoringEngine, TypingMetrics};
 use crate::sharing::{SharingPlatform, SharingService};
 use crate::Result;
 use crossterm::{
@@ -169,7 +169,12 @@ impl ResultScreen {
             } else if metrics.was_skipped {
                 execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
             } else {
-                execute!(stdout, SetForegroundColor(Color::Green))?;
+                execute!(
+                    stdout,
+                    SetForegroundColor(
+                        RankingTitle::for_score(metrics.challenge_score).terminal_color()
+                    )
+                )?;
             }
             execute!(stdout, Print(line))?;
             execute!(stdout, ResetColor)?;
@@ -421,7 +426,9 @@ impl ResultScreen {
             execute!(
                 stdout,
                 SetAttribute(Attribute::Bold),
-                SetForegroundColor(Color::Green)
+                SetForegroundColor(
+                    RankingTitle::for_score(session_metrics.challenge_score).terminal_color()
+                )
             )?;
             execute!(stdout, Print(line))?;
             execute!(stdout, ResetColor)?;

--- a/src/scoring/ranking_title.rs
+++ b/src/scoring/ranking_title.rs
@@ -27,6 +27,18 @@ impl RankingTier {
             RankingTier::Legendary => "fire",
         }
     }
+
+    /// Get the terminal color for this tier
+    pub fn terminal_color(&self) -> crossterm::style::Color {
+        use crossterm::style::Color;
+        match self {
+            RankingTier::Beginner => Color::Cyan,
+            RankingTier::Intermediate => Color::Blue,
+            RankingTier::Advanced => Color::Green,
+            RankingTier::Expert => Color::Yellow,
+            RankingTier::Legendary => Color::Red,
+        }
+    }
 }
 
 impl RankingTitle {
@@ -61,6 +73,11 @@ impl RankingTitle {
     /// Get the color palette name for ASCII art generation
     pub fn color_palette(&self) -> &'static str {
         self.tier.color_palette()
+    }
+
+    /// Get the terminal color for this ranking title
+    pub fn terminal_color(&self) -> crossterm::style::Color {
+        self.tier.terminal_color()
     }
 
     /// Get all ranking titles in order from lowest to highest score (matches engine.rs exactly)


### PR DESCRIPTION
## Summary
Closes: #125

This PR implements dynamic color-coding for session scores based on the user's ranking tier, providing better visual feedback about performance levels.

### Changes Made
- Added `terminal_color()` methods to `RankingTier` and `RankingTitle` enums
- Updated stage completion and session summary screens to use tier-based colors
- Replaced fixed green score colors with dynamic tier colors

### Tier Color Mapping
- **Beginner**: Cyan (bright, welcoming blue)
- **Intermediate**: Blue (darker, more serious blue)  
- **Advanced**: Green (traditional success color)
- **Expert**: Yellow (gold-like achievement color)
- **Legendary**: Red (bold, standout color for highest tier)

### Implementation Details
- Color logic is centralized in the ranking system for consistency
- Both stage completion and session summary screens now use dynamic colors
- Failed/skipped challenges retain their original red/grey colors
- Colors are determined directly from score rather than string matching

### Benefits
- **Enhanced Visual Feedback**: Users can immediately see their performance tier
- **Improved Motivation**: Color progression encourages improvement  
- **Better UX**: Consistent with existing tier-based color system
- **Meaningful Display**: Score color now carries information about achievement level

## Test Plan
- [x] Build passes successfully
- [x] All tests pass (147 total tests)
- [x] Clippy linting passes
- [x] Code formatting applied
- [x] Visual verification of color changes across different score ranges

🤖 Generated with [Claude Code](https://claude.ai/code)