### PR TITLE
fix: ensure panic error messages are visible to users

### DIFF
--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -15,8 +15,17 @@ pub fn run_cli(cli: Cli) -> Result<()> {
 }
 
 pub fn setup_signal_handlers() {
-    std::panic::set_hook(Box::new(|_| {
+    std::panic::set_hook(Box::new(|panic_info| {
+        use std::io::{stderr, Write};
+
+        // Ensure panic message is displayed before terminal cleanup
+        let _ = writeln!(stderr(), "Error: {}", panic_info);
+        let _ = stderr().flush();
+
         cleanup_terminal();
+
+        // Display panic info again after cleanup to ensure visibility
+        eprintln!("Application encountered a panic: {}", panic_info);
     }));
 
     ctrlc::set_handler(move || {


### PR DESCRIPTION
## Summary
Closes: #131

This PR fixes the issue where panic error messages were not visible to users during application crashes. The error content was being flushed before users could see it due to immediate terminal cleanup.

## Changes
- Modified the panic hook in `src/cli/runner.rs` to display error messages both before and after terminal cleanup
- Error messages are now written to stderr and flushed before cleanup
- Added a second error display after cleanup to ensure visibility

## Test Plan
- [x] Build succeeds with `cargo build`
- [x] All tests pass with `cargo test` 
- [x] Clippy checks pass
- [x] Manually tested panic scenarios - error messages now display correctly
- [x] Verified normal application functionality remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)