### PR TITLE
feat: align result file name display with colons

### DIFF
--- a/src/game/screens/result_screen.rs
+++ b/src/game/screens/result_screen.rs
@@ -477,13 +477,22 @@ impl ResultScreen {
             execute!(stdout, Print(&stage_label))?;
             execute!(stdout, ResetColor)?;
 
+            // Calculate maximum stage name width for alignment
+            let max_stage_name_width = stage_engines
+                .iter()
+                .take(5)
+                .map(|(stage_name, _)| stage_name.len())
+                .max()
+                .unwrap_or(0);
+
             for (i, (stage_name, engine)) in stage_engines.iter().enumerate().take(5) {
                 let result_line = format!(
-                    "{}: CPM {:.0}, WPM {:.0}, Acc {:.1}%",
+                    "{:>width$}: CPM {:.0}, WPM {:.0}, Acc {:.1}%",
                     stage_name,
                     engine.cpm(),
                     engine.wpm(),
-                    engine.accuracy()
+                    engine.accuracy(),
+                    width = max_stage_name_width
                 );
                 let result_col = center_col.saturating_sub(result_line.len() as u16 / 2);
                 execute!(


### PR DESCRIPTION
close: #130

## Summary
- Align file name displays using colons for consistent formatting in session summary results
- Add right-aligned formatting to pad shorter file names with spaces on the left
- Calculate maximum stage name width for proper tabular alignment
- Create a clean, readable layout for better user experience

## Changes
- Modified `show_session_summary_original` in `result_screen.rs` to add colon alignment
- Added calculation of maximum stage name width among displayed results
- Used `{:>width$}` format specifier for right-aligned padding

## Test plan
- [x] cargo check passes
- [x] cargo test passes (all 147 tests)
- [x] cargo clippy passes with no warnings
- [x] cargo fmt applied

🤖 Generated with [Claude Code](https://claude.ai/code)