### PR TITLE
fix: correct ranking position calculation to show higher scores first

### DIFF
--- a/src/scoring/rank_calculator.rs
+++ b/src/scoring/rank_calculator.rs
@@ -24,19 +24,19 @@ impl RankCalculator {
         }
         .to_string();
 
-        let tier_position = same_tier_ranks
-            .iter()
-            .position(|rank| rank.name() == current_rank.name())
-            .unwrap_or(0)
-            + 1;
+        let tier_position = same_tier_ranks.len()
+            - same_tier_ranks
+                .iter()
+                .position(|rank| rank.name() == current_rank.name())
+                .unwrap_or(0);
 
         let tier_total = same_tier_ranks.len();
 
-        let overall_position = all_ranks
-            .iter()
-            .position(|rank| rank.name() == current_rank.name())
-            .unwrap_or(0)
-            + 1;
+        let overall_position = all_ranks.len()
+            - all_ranks
+                .iter()
+                .position(|rank| rank.name() == current_rank.name())
+                .unwrap_or(0);
 
         let overall_total = all_ranks.len();
 


### PR DESCRIPTION
## Summary
- Fix ranking position calculation in `src/scoring/rank_calculator.rs` to display higher scores with smaller position numbers
- Both tier and overall position calculations now correctly show highest scores as rank 1

## Root Cause
Previously, the position calculation used the array index directly (`position + 1`), but since `all_ranks()` returns ranks ordered from lowest to highest score, this caused higher scores to get larger position numbers.

## Solution
Changed position calculation to `array.len() - position` to reverse the ranking order, ensuring higher scores get position 1, 2, 3, etc.

## Test Results
- Kernel Panic (highest score): Now shows 1/63 overall position ✅
- Hello World (lowest score): Now shows 63/63 overall position ✅

Closes #187

🤖 Generated with [Claude Code](https://claude.ai/code)