### PR TITLE
style: make all key descriptions use consistent dimmed colors

### DIFF
--- a/src/game/screens/analytics_screen.rs
+++ b/src/game/screens/analytics_screen.rs
@@ -1767,12 +1767,23 @@ impl AnalyticsScreen {
 
     fn render_controls(&self, f: &mut Frame, area: Rect) {
         let controls_line = Line::from(vec![
-            Span::styled("[←→/HL]", Style::default().fg(Color::Blue)),
-            Span::styled(" Switch View  ", Style::default().fg(Color::White)),
-            Span::styled("[R]", Style::default().fg(Color::Magenta)),
-            Span::styled(" Refresh  ", Style::default().fg(Color::White)),
-            Span::styled("[ESC]", Style::default().fg(Color::Red)),
-            Span::styled(" Back", Style::default().fg(Color::White)),
+            Span::styled(
+                "[←→/HL]",
+                Style::default().fg(Color::Blue).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Switch View  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[R]",
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Refresh  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[ESC]",
+                Style::default().fg(Color::Red).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Back", Style::default().fg(Color::DarkGray)),
         ]);
 
         let controls = Paragraph::new(controls_line).alignment(Alignment::Center);

--- a/src/game/screens/cancel_screen.rs
+++ b/src/game/screens/cancel_screen.rs
@@ -78,17 +78,32 @@ impl CancelScreen {
         let full_text_len = "[R] Retry | [T] Back to Title | [ESC] Session Summary & Exit".len();
         let nav_x = (terminal_width - full_text_len as u16) / 2;
         execute!(stdout, MoveTo(nav_x, center_y + 4))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[R]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Retry | "))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[T]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Back to Title | "))?;
-        execute!(stdout, SetForegroundColor(Color::Red))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Red),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[ESC]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Session Summary & Exit"))?;
 
         execute!(stdout, ResetColor)?;

--- a/src/game/screens/details_dialog.rs
+++ b/src/game/screens/details_dialog.rs
@@ -222,9 +222,14 @@ impl DetailsDialog {
         let instruction = "[ESC] Return";
         let instruction_col = center_col.saturating_sub(instruction.len() as u16 / 2);
         execute!(stdout, MoveTo(instruction_col, current_row))?;
-        execute!(stdout, SetForegroundColor(Color::Red))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Red),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[ESC]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Return"))?;
         execute!(stdout, ResetColor)?;
 

--- a/src/game/screens/failure_screen.rs
+++ b/src/game/screens/failure_screen.rs
@@ -81,17 +81,32 @@ impl FailureScreen {
         let full_text_len = "[R] Retry | [T] Back to Title | [ESC] Session Summary & Exit".len();
         let nav_x = (terminal_width - full_text_len as u16) / 2;
         execute!(stdout, MoveTo(nav_x, center_y + 4))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[R]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Retry | "))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[T]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Back to Title | "))?;
-        execute!(stdout, SetForegroundColor(Color::Red))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Red),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[ESC]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Session Summary & Exit"))?;
 
         execute!(stdout, ResetColor)?;

--- a/src/game/screens/history_screen.rs
+++ b/src/game/screens/history_screen.rs
@@ -362,17 +362,40 @@ impl HistoryScreen {
 
         // Controls at the bottom row - matching title screen colors
         let controls_line = Line::from(vec![
-            Span::styled("[↑↓/JK] Navigate  ", Style::default().fg(Color::White)),
-            Span::styled("[SPACE]", Style::default().fg(Color::Green)),
-            Span::styled(" Details  ", Style::default().fg(Color::White)),
-            Span::styled("[F]", Style::default().fg(Color::Blue)),
-            Span::styled(" Filter  ", Style::default().fg(Color::White)),
-            Span::styled("[S]", Style::default().fg(Color::Cyan)),
-            Span::styled(" Sort  ", Style::default().fg(Color::White)),
-            Span::styled("[R]", Style::default().fg(Color::Magenta)),
-            Span::styled(" Refresh  ", Style::default().fg(Color::White)),
-            Span::styled("[ESC]", Style::default().fg(Color::Red)),
-            Span::styled(" Back", Style::default().fg(Color::White)),
+            Span::styled(
+                "[↑↓/JK]",
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Navigate  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[SPACE]",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Details  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[F]",
+                Style::default().fg(Color::Blue).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Filter  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[S]",
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Sort  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[R]",
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Refresh  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[ESC]",
+                Style::default().fg(Color::Red).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Back", Style::default().fg(Color::DarkGray)),
         ]);
 
         let controls = Paragraph::new(controls_line).alignment(Alignment::Center);

--- a/src/game/screens/info_dialog.rs
+++ b/src/game/screens/info_dialog.rs
@@ -168,17 +168,32 @@ impl InfoDialog {
         let total_instructions_len = "[↑↓/JK] Navigate [SPACE] Select [ESC] Close".len();
         let instructions_col = center_col.saturating_sub(total_instructions_len as u16 / 2);
         execute!(stdout, MoveTo(instructions_col, start_row + 7))?;
-        execute!(stdout, SetForegroundColor(Color::Cyan))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[↑↓/JK]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Navigate "))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[SPACE]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Select "))?;
-        execute!(stdout, SetForegroundColor(Color::Red))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Red),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[ESC]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Close"))?;
         execute!(stdout, ResetColor)?;
 
@@ -297,9 +312,14 @@ impl InfoDialog {
         let total_back_len = back_key.len() + back_label.len();
         let instructions_col = center_col.saturating_sub(total_back_len as u16 / 2);
         execute!(stdout, MoveTo(instructions_col, start_row + 6))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print(back_key))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(back_label))?;
         execute!(stdout, ResetColor)?;
 

--- a/src/game/screens/session_detail_screen.rs
+++ b/src/game/screens/session_detail_screen.rs
@@ -158,9 +158,16 @@ impl SessionDetailScreen {
 
         // Controls at the bottom
         let controls_line = Line::from(vec![
-            Span::styled("[↑↓/JK] Scroll Stages  ", Style::default().fg(Color::White)),
-            Span::styled("[ESC]", Style::default().fg(Color::Red)),
-            Span::styled(" Back", Style::default().fg(Color::White)),
+            Span::styled(
+                "[↑↓/JK]",
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Scroll Stages  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "[ESC]",
+                Style::default().fg(Color::Red).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(" Back", Style::default().fg(Color::DarkGray)),
         ]);
 
         let controls = Paragraph::new(controls_line).alignment(Alignment::Center);

--- a/src/game/screens/session_summary_screen.rs
+++ b/src/game/screens/session_summary_screen.rs
@@ -332,9 +332,14 @@ impl SessionSummaryScreen {
                 execute!(stdout, Print("  "))?;
                 _pos += 2;
             }
-            execute!(stdout, SetForegroundColor(*key_color))?;
+            execute!(
+                stdout,
+                SetForegroundColor(*key_color),
+                SetAttribute(Attribute::Dim)
+            )?;
             execute!(stdout, Print(key))?;
-            execute!(stdout, SetForegroundColor(Color::White))?;
+            execute!(stdout, SetAttribute(Attribute::Reset))?;
+            execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
             execute!(stdout, Print(label))?;
             _pos += key.len() + label.len();
         }
@@ -356,9 +361,14 @@ impl SessionSummaryScreen {
             if i > 0 {
                 execute!(stdout, Print("  "))?;
             }
-            execute!(stdout, SetForegroundColor(*key_color))?;
+            execute!(
+                stdout,
+                SetForegroundColor(*key_color),
+                SetAttribute(Attribute::Dim)
+            )?;
             execute!(stdout, Print(key))?;
-            execute!(stdout, SetForegroundColor(Color::White))?;
+            execute!(stdout, SetAttribute(Attribute::Reset))?;
+            execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
             execute!(stdout, Print(label))?;
             execute!(stdout, ResetColor)?;
         }

--- a/src/game/screens/stage_summary_screen.rs
+++ b/src/game/screens/stage_summary_screen.rs
@@ -207,13 +207,23 @@ impl StageSummaryScreen {
         let start_col = center_col.saturating_sub(total_text_length as u16 / 2);
 
         execute!(stdout, MoveTo(start_col, options_row))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[SPACE]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Continue  "))?;
-        execute!(stdout, SetForegroundColor(Color::Red))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Red),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[ESC]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Quit"))?;
         execute!(stdout, ResetColor)?;
         stdout.flush()?;

--- a/src/game/screens/title_screen.rs
+++ b/src/game/screens/title_screen.rs
@@ -174,9 +174,14 @@ impl TitleScreen {
         let change_display_width = 26u16; // "[←→/HL] Change Difficulty"
         let change_col = center_col.saturating_sub(change_display_width / 2) + 2;
         execute!(stdout, MoveTo(change_col, instructions_start_row))?;
-        execute!(stdout, SetForegroundColor(Color::Blue))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Blue),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[←→/HL]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Change Difficulty"))?;
         execute!(stdout, ResetColor)?;
 
@@ -184,17 +189,32 @@ impl TitleScreen {
         let secondary_display_width = 38u16; // "[R] history  [A] analytics  [I/?] info"
         let secondary_col = center_col.saturating_sub(secondary_display_width / 2) + 2;
         execute!(stdout, MoveTo(secondary_col, instructions_start_row + 1))?;
-        execute!(stdout, SetForegroundColor(Color::Cyan))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[R]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" History  "))?;
-        execute!(stdout, SetForegroundColor(Color::Cyan))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[A]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Analytics  "))?;
-        execute!(stdout, SetForegroundColor(Color::Cyan))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Cyan),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[I/?]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Info"))?;
         execute!(stdout, ResetColor)?;
 
@@ -202,13 +222,23 @@ impl TitleScreen {
         let primary_display_width = 22u16; // "[SPACE] Start  [ESC] Quit"
         let primary_col = center_col.saturating_sub(primary_display_width / 2) + 2;
         execute!(stdout, MoveTo(primary_col, instructions_start_row + 2))?;
-        execute!(stdout, SetForegroundColor(Color::Green))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Green),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[SPACE]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Start  "))?;
-        execute!(stdout, SetForegroundColor(Color::Red))?;
+        execute!(
+            stdout,
+            SetForegroundColor(Color::Red),
+            SetAttribute(Attribute::Dim)
+        )?;
         execute!(stdout, Print("[ESC]"))?;
-        execute!(stdout, SetForegroundColor(Color::White))?;
+        execute!(stdout, SetAttribute(Attribute::Reset))?;
+        execute!(stdout, SetForegroundColor(Color::DarkGrey))?;
         execute!(stdout, Print(" Quit"))?;
         execute!(stdout, ResetColor)?;
 


### PR DESCRIPTION
close: #189

## Summary
- Apply `Attribute::Dim` to all key bindings while preserving original colors  
- Change all description text to use `DarkGrey`/`DarkGray` for consistency
- Update both crossterm-based screens (`SetAttribute`) and ratatui-based screens (`add_modifier`)

## Changes Made
- **Title Screen**: Dimmed key colors for `[←→/HL]`, `[R]`, `[A]`, `[I/?]`, `[SPACE]`, `[ESC]`
- **History Screen**: Dimmed navigation and action keys `[↑↓/JK]`, `[SPACE]`, `[F]`, `[S]`, `[R]`, `[ESC]`  
- **Analytics Screen**: Dimmed view switching keys `[←→/HL]`, `[R]`, `[ESC]`
- **Session Summary**: Dimmed all option keys while maintaining functionality
- **Dialog Screens**: Consistent dimming for navigation and action keys
- **All description text**: Changed to `DarkGrey`/`DarkGray` for better visual hierarchy

## Benefits
- Better visual hierarchy with consistent styling across all screens
- Reduced visual noise while maintaining color-coded functionality
- Improved accessibility with dimmed but still distinguishable key bindings

## Test Plan
- [x] `cargo check` - compiles without errors
- [x] `cargo test` - all tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - no warnings
- [x] `cargo fmt` - code formatted

🤖 Generated with [Claude Code](https://claude.ai/code)