### PR TITLE
feat: improve exclude patterns for dependency and generated source directories

### DIFF
--- a/src/extractor/models/options.rs
+++ b/src/extractor/models/options.rs
@@ -10,39 +10,74 @@ impl Default for ExtractionOptions {
         Self {
             include_patterns: super::language::LanguageRegistry::all_file_patterns(),
             exclude_patterns: vec![
-                // Build directories (common across multiple languages)
-                "**/target/**".to_string(), // Rust, Maven (Java)
-                "**/build/**".to_string(),  // JS/TS, Java (Gradle), C/C++, Kotlin, Dart
-                "**/dist/**".to_string(),   // JS/TS build output
-                "**/bin/**".to_string(),    // Java, C#
-                "**/obj/**".to_string(),    // C#/.NET
-                // Package/dependency managers
+                // === Common build directories ===
+                "**/build/**".to_string(),
+                "**/dist/**".to_string(),
+                "**/target/**".to_string(),
+                "**/bin/**".to_string(),
+                "**/obj/**".to_string(),
+                // === Dependency directories ===
                 "**/node_modules/**".to_string(), // JavaScript/TypeScript
-                "**/vendor/**".to_string(),       // Go, PHP
-                "**/packages/**".to_string(),     // C#/.NET NuGet
+                "**/vendor/**".to_string(),       // Go, PHP, Ruby
+                // === Language-specific patterns ===
+
                 // Python
                 "**/__pycache__/**".to_string(),
                 "**/*.pyc".to_string(),
                 "**/venv/**".to_string(),
                 "**/.venv/**".to_string(),
                 "**/env/**".to_string(),
-                // JavaScript/TypeScript frameworks
-                "**/.next/**".to_string(), // Next.js
-                // Java compiled files
+                // JavaScript/TypeScript
+                "**/.next/**".to_string(),       // Next.js
+                "**/.nuxt/**".to_string(),       // Nuxt.js
+                "**/coverage/**".to_string(),    // Test coverage
+                "**/.nyc_output/**".to_string(), // NYC coverage tool
+                // Java/Kotlin
                 "**/*.class".to_string(),
+                "**/gradle/**".to_string(),   // Gradle wrapper
+                "**/.gradle/**".to_string(),  // Gradle cache
+                "**/buildSrc/**".to_string(), // Gradle buildSrc
+                "**/.m2/**".to_string(),      // Maven cache
+                "**/.ivy2/**".to_string(),    // SBT/Ivy cache
+                // Ruby
+                "**/bundle/**".to_string(),  // Bundler
+                "**/.bundle/**".to_string(), // Bundler cache
                 // Swift/iOS
                 "**/.build/**".to_string(),
                 "**/DerivedData/**".to_string(),
-                // C/C++ compiled files
+                "**/Pods/**".to_string(),     // CocoaPods
+                "**/Carthage/**".to_string(), // Carthage
+                // C#/.NET
+                "**/packages.config".to_string(), // NuGet packages.config
+                "**/packages/**/*.dll".to_string(), // NuGet compiled libraries
+                "**/packages/**/*.pdb".to_string(), // NuGet debug symbols
+                "**/packages/**/*.xml".to_string(), // NuGet documentation
+                // C/C++
                 "**/*.o".to_string(),
                 "**/*.so".to_string(),
                 "**/*.a".to_string(),
+                "**/CMakeFiles/**".to_string(),
+                "**/cmake-build-*/**".to_string(),
+                "**/.vs/**".to_string(),     // Visual Studio
+                "**/x64/**".to_string(),     // VS build dirs
+                "**/x86/**".to_string(),     // VS build dirs
+                "**/Debug/**".to_string(),   // VS/MSBuild
+                "**/Release/**".to_string(), // VS/MSBuild
                 // Dart/Flutter
                 "**/.dart_tool/**".to_string(),
                 // Haskell
                 "**/.stack-work/**".to_string(),
                 "**/dist-newstyle/**".to_string(),
-                // Version control & general
+                // === Generated code ===
+                "**/generated/**".to_string(),
+                "**/.generated/**".to_string(),
+                "**/gen/**".to_string(),
+                "**/codegen/**".to_string(),
+                "**/*_pb2.py".to_string(), // Python protobuf
+                "**/*.pb.go".to_string(),  // Go protobuf
+                // === Build tools and caches ===
+                "**/bazel-*/**".to_string(), // Bazel
+                // === System and temporary files ===
                 "**/.git/**".to_string(),
                 "**/tmp/**".to_string(),
                 "**/temp/**".to_string(),


### PR DESCRIPTION
## Summary
- Add missing dependency directories for supported languages (iOS CocoaPods/Carthage, Ruby Bundler)
- Add build script directories and caches (Gradle, Maven, SBT/Ivy, CMake, Visual Studio, Bazel)
- Add generated source directories and files (protobuf, codegen patterns)
- Reorganize exclude patterns by logical categories for better maintainability
- Use C#-specific file patterns to avoid excluding JavaScript monorepo packages

## What's Changed
- **Dependency directories**: Added `**/Pods/**`, `**/Carthage/**` (iOS), `**/bundle/**`, `**/.bundle/**` (Ruby)
- **Build systems**: Added Gradle, Maven, CMake, Visual Studio, Bazel patterns
- **Generated code**: Added `**/generated/**`, `**/gen/**`, `**/codegen/**`, protobuf patterns
- **Organization**: Restructured patterns into logical categories (Common build dirs, Dependencies, Language-specific, Generated code, System files)
- **JavaScript compatibility**: Changed C# NuGet patterns from `**/packages/**` to specific file extensions to preserve JavaScript monorepo source files

## Test Plan
- [x] All existing tests pass
- [x] Compilation and linting successful
- [x] Exclude patterns correctly filter out dependency/generated files while preserving application source code

Close: #206

🤖 Generated with [Claude Code](https://claude.ai/code)