### PR TITLE
fix: finalize TotalResult to prevent MAX value display in TotalSummaryScreen

### DIFF
--- a/src/game/screens/total_summary_screen.rs
+++ b/src/game/screens/total_summary_screen.rs
@@ -111,7 +111,8 @@ impl Screen for TotalSummaryScreen {
         _total_result: Option<&crate::scoring::TotalResult>,
     ) -> Result<()> {
         if !self.displayed {
-            let total_result = Self::get_total_result_from_tracker().unwrap_or_default();
+            let mut total_result = Self::get_total_result_from_tracker().unwrap_or_default();
+            total_result.finalize(); // Ensure MAX values are converted to 0.0
 
             let _ = TotalSummaryScreen::show(&total_result);
             self.displayed = true;


### PR DESCRIPTION
## Summary
- Fix TotalSummaryScreen displaying f64::MAX values when no sessions exist
- Call finalize() on TotalResult to convert MAX values to 0.0 for proper display

## Test plan
- [x] Verify TotalSummaryScreen shows 0.0 instead of very large numbers for worst values when no sessions exist
- [x] Code compiles without warnings
- [x] Follows existing patterns in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)