### PR TITLE
feat: implement challenge caching system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +333,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -576,6 +594,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,11 +728,13 @@ version = "0.6.2"
 dependencies = [
  "anyhow",
  "atty",
+ "bincode",
  "chrono",
  "clap",
  "crossterm 0.29.0",
  "ctrlc",
  "dirs",
+ "flate2",
  "git2",
  "glob",
  "ignore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +512,16 @@ name = "destructure_traitobject"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -679,6 +717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +799,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "streaming-iterator",
  "tempfile",
  "thiserror",
@@ -2080,6 +2129,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2795,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ctrlc = "3.5.0"
+dirs = "6.0"
 uuid = { version = "1.0", features = ["v4"] }
 rand = { version = "0.9", features = ["std_rng"] }
 once_cell = "1.19"
@@ -64,7 +65,6 @@ rayon = "1.8"
 open = "5.0"
 urlencoding = "2.1"
 git2 = { version = "0.18", features = ["vendored-openssl"] }
-dirs = "6.0"
 streaming-iterator = "0.1"
 log = "0.4"
 log4rs = "1.4"
@@ -72,6 +72,8 @@ tempfile = "3.22"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 reqwest = { version = "0.12", features = ["json"] }
 atty = "0.2"
+bincode = "1.3"
+flate2 = "1.0"
 
 [dev-dependencies]
 paste = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ reqwest = { version = "0.12", features = ["json"] }
 atty = "0.2"
 bincode = "1.3"
 flate2 = "1.0"
+sha2 = "0.10"
 
 [dev-dependencies]
 paste = "1.0"

--- a/src/cache/challenge_cache.rs
+++ b/src/cache/challenge_cache.rs
@@ -1,0 +1,244 @@
+use super::gzip_storage::GzipStorage;
+use crate::models::{Challenge, GitRepository};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ChallengePointer {
+    id: String,
+    source_file_path: Option<String>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+    language: Option<String>,
+    comment_ranges: Vec<(usize, usize)>,
+    difficulty_level: Option<crate::game::stage_repository::DifficultyLevel>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CacheData {
+    commit_hash: String,
+    challenge_pointers: Vec<ChallengePointer>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChallengeCache {
+    cache_dir: PathBuf,
+}
+
+impl ChallengeCache {
+    pub fn new() -> Self {
+        let mut cache_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        cache_dir.push(".gittype");
+        cache_dir.push("cache");
+
+        Self { cache_dir }
+    }
+
+    pub fn with_cache_dir(cache_dir: PathBuf) -> Self {
+        Self { cache_dir }
+    }
+
+    pub fn save(&self, repo: &GitRepository, challenges: &[Challenge]) -> Result<(), String> {
+        // Skip caching for dirty repositories
+        if repo.is_dirty {
+            return Ok(());
+        }
+
+        let cache_file = self.get_cache_file(repo);
+
+        let challenge_pointers: Vec<ChallengePointer> = challenges
+            .iter()
+            .map(|challenge| ChallengePointer {
+                id: challenge.id.clone(),
+                source_file_path: challenge.source_file_path.clone(),
+                start_line: challenge.start_line,
+                end_line: challenge.end_line,
+                language: challenge.language.clone(),
+                comment_ranges: challenge.comment_ranges.clone(),
+                difficulty_level: challenge.difficulty_level,
+            })
+            .collect();
+
+        let cache_data = CacheData {
+            commit_hash: repo.commit_hash.clone().unwrap_or_default(),
+            challenge_pointers,
+        };
+
+        GzipStorage::save(&cache_file, &cache_data)
+    }
+
+    pub fn load_with_progress(
+        &self,
+        repo: &GitRepository,
+        progress_reporter: Option<&dyn crate::game::screens::loading_screen::ProgressReporter>,
+    ) -> Option<Vec<Challenge>> {
+        use rayon::prelude::*;
+        use std::sync::{Arc, Mutex};
+
+        // Skip cache for dirty repositories
+        if repo.is_dirty {
+            return None;
+        }
+
+        let cache_file = self.get_cache_file(repo);
+        let cache_data: CacheData = GzipStorage::load(&cache_file)?;
+
+        // Check if commit hash matches
+        if cache_data.commit_hash != repo.commit_hash.as_deref().unwrap_or("") {
+            return None;
+        }
+
+        // Reconstruct challenges from pointers with parallel progress
+        let repo_root = repo.root_path.as_ref()?;
+        let total = cache_data.challenge_pointers.len();
+        let processed = Arc::new(Mutex::new(0usize));
+
+        let challenges: Vec<Challenge> = cache_data
+            .challenge_pointers
+            .par_iter()
+            .filter_map(|pointer| {
+                let challenge = self.reconstruct_challenge(pointer, repo_root);
+
+                // Report progress atomically
+                if let Some(reporter) = progress_reporter {
+                    let mut count = processed.lock().unwrap();
+                    *count += 1;
+                    let current = *count;
+                    drop(count);
+
+                    reporter.set_file_counts(
+                        crate::game::models::loading_steps::StepType::CacheCheck,
+                        current,
+                        total,
+                        Some(format!("Reconstructing challenge {}/{}", current, total)),
+                    );
+                }
+
+                challenge
+            })
+            .collect();
+
+        Some(challenges)
+    }
+
+    pub fn clear(&self) -> Result<(), String> {
+        if self.cache_dir.exists() {
+            fs::remove_dir_all(&self.cache_dir)
+                .map_err(|e| format!("Failed to clear cache: {}", e))?;
+        }
+        Ok(())
+    }
+
+    pub fn stats(&self) -> Result<(usize, u64), String> {
+        if !self.cache_dir.exists() {
+            return Ok((0, 0));
+        }
+
+        let mut count = 0;
+        let mut total_size = 0u64;
+
+        for entry in
+            fs::read_dir(&self.cache_dir).map_err(|e| format!("Failed to read cache dir: {}", e))?
+        {
+            let entry = entry.map_err(|e| format!("Failed to read cache entry: {}", e))?;
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.ends_with(".bin"))
+            {
+                count += 1;
+                if let Ok(metadata) = entry.metadata() {
+                    total_size += metadata.len();
+                }
+            }
+        }
+
+        Ok((count, total_size))
+    }
+
+    pub fn invalidate_repo(&self, repo: &GitRepository) -> Result<bool, String> {
+        let cache_file = self.get_cache_file(repo);
+        if cache_file.exists() {
+            fs::remove_file(cache_file)
+                .map_err(|e| format!("Failed to invalidate cache: {}", e))?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn list_keys(&self) -> Result<Vec<String>, String> {
+        if !self.cache_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let keys = fs::read_dir(&self.cache_dir)
+            .map_err(|e| format!("Failed to read cache dir: {}", e))?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .filter(|name| name.ends_with(".bin"))
+                    .and_then(|name| {
+                        let cache_key = name.trim_end_matches(".bin");
+                        GzipStorage::load::<CacheData>(&entry.path())
+                            .map(|cache_data| format!("{}:{}", cache_key, cache_data.commit_hash))
+                    })
+            })
+            .collect();
+
+        Ok(keys)
+    }
+
+    fn reconstruct_challenge(
+        &self,
+        pointer: &ChallengePointer,
+        repo_root: &std::path::Path,
+    ) -> Option<Challenge> {
+        let file_path = pointer.source_file_path.as_ref()?;
+        let absolute_path = repo_root.join(file_path);
+
+        // Read file content
+        let file_content = fs::read_to_string(&absolute_path).ok()?;
+        let lines: Vec<&str> = file_content.lines().collect();
+
+        // Extract code content based on line numbers
+        let code_content = match (pointer.start_line, pointer.end_line) {
+            (Some(start), Some(end)) => {
+                if start <= lines.len() && end <= lines.len() && start <= end {
+                    lines[start.saturating_sub(1)..end].join("\n")
+                } else {
+                    return None;
+                }
+            }
+            _ => file_content, // Fallback to entire file if no line info
+        };
+
+        Some(Challenge {
+            id: pointer.id.clone(),
+            source_file_path: pointer.source_file_path.clone(),
+            code_content,
+            start_line: pointer.start_line,
+            end_line: pointer.end_line,
+            language: pointer.language.clone(),
+            comment_ranges: pointer.comment_ranges.clone(),
+            difficulty_level: pointer.difficulty_level,
+        })
+    }
+
+    fn get_cache_file(&self, repo: &GitRepository) -> PathBuf {
+        fs::create_dir_all(&self.cache_dir).ok();
+        let cache_key = repo.cache_key();
+        self.cache_dir.join(format!("{}.bin", cache_key))
+    }
+}
+
+impl Default for ChallengeCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub static CHALLENGE_CACHE: once_cell::sync::Lazy<ChallengeCache> =
+    once_cell::sync::Lazy::new(ChallengeCache::new);

--- a/src/cache/gzip_storage.rs
+++ b/src/cache/gzip_storage.rs
@@ -1,0 +1,32 @@
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use std::fs;
+use std::io::{Read, Write};
+
+#[derive(Debug)]
+pub struct GzipStorage;
+
+impl GzipStorage {
+    pub fn save<T: serde::Serialize>(path: &std::path::Path, data: &T) -> Result<(), String> {
+        let binary_data =
+            bincode::serialize(data).map_err(|e| format!("Failed to serialize data: {}", e))?;
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(&binary_data)
+            .map_err(|e| format!("Failed to compress data: {}", e))?;
+        let compressed_data = encoder
+            .finish()
+            .map_err(|e| format!("Failed to finish compression: {}", e))?;
+
+        fs::write(path, compressed_data).map_err(|e| format!("Failed to save file: {}", e))
+    }
+
+    pub fn load<T: serde::de::DeserializeOwned>(path: &std::path::Path) -> Option<T> {
+        let compressed_data = fs::read(path).ok()?;
+        let mut decoder = GzDecoder::new(&compressed_data[..]);
+        let mut binary_data = Vec::new();
+
+        decoder.read_to_end(&mut binary_data).ok()?;
+
+        bincode::deserialize(&binary_data).ok()
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,5 @@
+pub mod challenge_cache;
+pub mod gzip_storage;
+
+pub use challenge_cache::{ChallengeCache, CHALLENGE_CACHE};
+pub use gzip_storage::GzipStorage;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -70,4 +70,19 @@ pub enum Commands {
         #[arg(long)]
         output: Option<PathBuf>,
     },
+    /// Manage challenge cache
+    Cache {
+        #[command(subcommand)]
+        cache_command: CacheCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheCommands {
+    /// Show cache statistics
+    Stats,
+    /// Clear all cached challenges
+    Clear,
+    /// List cached repository keys
+    List,
 }

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -1,4 +1,4 @@
-use crate::cli::args::{Cli, Commands};
+use crate::cli::args::{CacheCommands, Cli, Commands};
 use crate::cli::commands::{run_export, run_game_session, run_history, run_stats};
 use crate::logging::{setup_console_logging, setup_logging};
 use crate::Result;
@@ -15,6 +15,70 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
         Some(Commands::History) => run_history(),
         Some(Commands::Stats) => run_stats(),
         Some(Commands::Export { format, output }) => run_export(format.clone(), output.clone()),
+        Some(Commands::Cache { cache_command }) => run_cache_command(cache_command),
         None => run_game_session(cli),
     }
+}
+
+fn run_cache_command(cache_command: &CacheCommands) -> Result<()> {
+    use crate::cache::CHALLENGE_CACHE;
+
+    match cache_command {
+        CacheCommands::Stats => match CHALLENGE_CACHE.stats() {
+            Ok((file_count, total_bytes)) => {
+                println!("Challenge Cache Statistics:");
+                println!("  Cached repositories: {}", file_count);
+                if total_bytes > 0 {
+                    if total_bytes < 1024 {
+                        println!("  Total size: {} bytes", total_bytes);
+                    } else if total_bytes < 1024 * 1024 {
+                        println!("  Total size: {:.1} KB", total_bytes as f64 / 1024.0);
+                    } else if total_bytes < 1024 * 1024 * 1024 {
+                        println!(
+                            "  Total size: {:.1} MB",
+                            total_bytes as f64 / (1024.0 * 1024.0)
+                        );
+                    } else {
+                        println!(
+                            "  Total size: {:.1} GB",
+                            total_bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+                        );
+                    }
+                } else {
+                    println!("  Total size: 0 bytes");
+                }
+            }
+            Err(e) => {
+                eprintln!("Error getting cache stats: {}", e);
+                return Err(crate::GitTypeError::TerminalError(e));
+            }
+        },
+        CacheCommands::Clear => match CHALLENGE_CACHE.clear() {
+            Ok(()) => {
+                println!("Challenge cache cleared successfully.");
+            }
+            Err(e) => {
+                eprintln!("Error clearing cache: {}", e);
+                return Err(crate::GitTypeError::TerminalError(e));
+            }
+        },
+        CacheCommands::List => match CHALLENGE_CACHE.list_keys() {
+            Ok(keys) => {
+                if keys.is_empty() {
+                    println!("No cached challenges found.");
+                } else {
+                    println!("Cached repository keys:");
+                    for key in keys {
+                        println!("  {}", key);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Error listing cache keys: {}", e);
+                return Err(crate::GitTypeError::TerminalError(e));
+            }
+        },
+    }
+
+    Ok(())
 }

--- a/src/game/models/loading_steps/cache_check_step.rs
+++ b/src/game/models/loading_steps/cache_check_step.rs
@@ -1,0 +1,110 @@
+use super::{ExecutionContext, Step, StepResult, StepType};
+use crate::cache::CHALLENGE_CACHE;
+use crate::ui::Colors;
+use crate::Result;
+use ratatui::style::Color;
+
+#[derive(Debug, Clone)]
+pub struct CacheCheckStep;
+
+impl Step for CacheCheckStep {
+    fn step_type(&self) -> StepType {
+        StepType::CacheCheck
+    }
+    fn step_number(&self) -> usize {
+        3
+    }
+    fn description(&self) -> &str {
+        "Checking cache for existing challenges"
+    }
+    fn step_name(&self) -> &str {
+        "Cache check"
+    }
+
+    fn icon(&self, is_current: bool, is_completed: bool) -> (&str, Color) {
+        if is_completed {
+            ("✓", Colors::SUCCESS)
+        } else if is_current {
+            ("🔍", Colors::WARNING)
+        } else {
+            ("◦", Colors::MUTED)
+        }
+    }
+
+    fn supports_progress(&self) -> bool {
+        true
+    }
+
+    fn progress_unit(&self) -> &str {
+        "challenges"
+    }
+
+    fn format_progress(
+        &self,
+        processed: usize,
+        total: usize,
+        progress: f64,
+        spinner: char,
+    ) -> String {
+        format!(
+            "{} {:.1}% {}/{} challenges from cache",
+            spinner,
+            progress * 100.0,
+            processed,
+            total
+        )
+    }
+
+    fn execute(&self, context: &mut ExecutionContext) -> Result<StepResult> {
+        // Early return if no git repository info
+        let Some(ref git_repo) = context.git_repository else {
+            log::info!("No git repository info - skipping cache check");
+            return Ok(StepResult::Skipped);
+        };
+
+        log::info!(
+            "CacheCheckStep - Git repository info: url={}, commit={:?}, is_dirty={}",
+            git_repo.remote_url,
+            git_repo.commit_hash,
+            git_repo.is_dirty
+        );
+
+        // Early return if repository is dirty
+        if git_repo.is_dirty {
+            log::info!(
+                "Repository is dirty - skipping cache check for {}",
+                git_repo.remote_url
+            );
+            return Ok(StepResult::Skipped);
+        }
+
+        // Try to load from cache
+        let Some(cached_challenges) = CHALLENGE_CACHE.load_with_progress(
+            git_repo,
+            context
+                .loading_screen
+                .map(|s| s as &dyn crate::game::screens::loading_screen::ProgressReporter),
+        ) else {
+            log::info!(
+                "Cache miss for {} - proceeding with full extraction",
+                git_repo.remote_url
+            );
+            return Ok(StepResult::Skipped);
+        };
+
+        // Cache hit! Store challenges and skip remaining steps
+        log::info!(
+            "Cache hit! Reconstructed {} challenges for {} (clean repository)",
+            cached_challenges.len(),
+            git_repo.remote_url
+        );
+
+        use crate::game::GameData;
+        GameData::set_results(cached_challenges, context.git_repository.clone())?;
+
+        // Mark that cache was used so other steps can skip
+        context.cache_used = true;
+
+        Ok(StepResult::Skipped)
+    }
+}

--- a/src/game/models/loading_steps/extracting_step.rs
+++ b/src/game/models/loading_steps/extracting_step.rs
@@ -11,7 +11,7 @@ impl Step for ExtractingStep {
         StepType::Extracting
     }
     fn step_number(&self) -> usize {
-        4
+        5
     }
     fn description(&self) -> &str {
         "Extracting functions, classes, and code blocks"

--- a/src/game/models/loading_steps/finalizing_step.rs
+++ b/src/game/models/loading_steps/finalizing_step.rs
@@ -16,7 +16,7 @@ impl Step for FinalizingStep {
         StepType::Finalizing
     }
     fn step_number(&self) -> usize {
-        7
+        8
     }
     fn description(&self) -> &str {
         "Preparing content for optimal typing practice"

--- a/src/game/models/loading_steps/mod.rs
+++ b/src/game/models/loading_steps/mod.rs
@@ -4,6 +4,7 @@ use crate::Result;
 use ratatui::style::Color;
 use std::path::PathBuf;
 
+pub mod cache_check_step;
 pub mod cloning_step;
 pub mod database_init_step;
 pub mod extracting_step;
@@ -12,6 +13,7 @@ pub mod generating_step;
 pub mod scanning_step;
 pub mod step_manager;
 
+pub use cache_check_step::CacheCheckStep;
 pub use cloning_step::CloningStep;
 pub use database_init_step::DatabaseInitStep;
 pub use extracting_step::ExtractingStep;
@@ -23,6 +25,7 @@ pub use step_manager::StepManager;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum StepType {
     DatabaseInit,
+    CacheCheck,
     Cloning,
     Scanning,
     Extracting,
@@ -42,6 +45,7 @@ pub struct ExecutionContext<'a> {
     pub git_repository: Option<crate::models::GitRepository>,
     pub scanned_files: Option<Vec<PathBuf>>, // Temporary storage for step results
     pub chunks: Option<Vec<crate::extractor::models::CodeChunk>>, // Chunks from ExtractingStep
+    pub cache_used: bool, // Flag to indicate cache was used and remaining steps should be skipped
 }
 
 #[derive(Debug)]

--- a/src/game/models/loading_steps/scanning_step.rs
+++ b/src/game/models/loading_steps/scanning_step.rs
@@ -11,7 +11,7 @@ impl Step for ScanningStep {
         StepType::Scanning
     }
     fn step_number(&self) -> usize {
-        3
+        4
     }
     fn description(&self) -> &str {
         "Scanning repository files"

--- a/src/game/models/loading_steps/step_manager.rs
+++ b/src/game/models/loading_steps/step_manager.rs
@@ -1,6 +1,6 @@
 use super::{
-    CloningStep, DatabaseInitStep, ExecutionContext, ExtractingStep, FinalizingStep,
-    GeneratingStep, ScanningStep, Step, StepResult,
+    CacheCheckStep, CloningStep, DatabaseInitStep, ExecutionContext, ExtractingStep,
+    FinalizingStep, GeneratingStep, ScanningStep, Step, StepResult,
 };
 use crate::game::screens::loading_screen::ProgressReporter;
 use crate::Result;
@@ -21,6 +21,7 @@ impl StepManager {
             steps: vec![
                 Box::new(DatabaseInitStep),
                 Box::new(CloningStep),
+                Box::new(CacheCheckStep),
                 Box::new(ScanningStep),
                 Box::new(ExtractingStep),
                 Box::new(GeneratingStep),
@@ -57,6 +58,11 @@ impl StepManager {
         for step in &self.steps {
             // Skip step if it can be skipped
             if step.can_skip(context) {
+                continue;
+            }
+
+            // Skip remaining steps if cache was used (except finalization)
+            if context.cache_used && step.step_type() != super::StepType::Finalizing {
                 continue;
             }
 

--- a/src/game/screens/loading_screen.rs
+++ b/src/game/screens/loading_screen.rs
@@ -253,6 +253,7 @@ impl LoadingScreen {
             git_repository: None,
             scanned_files: None,
             chunks: None,
+            cache_used: false,
         };
 
         match step_manager.execute_pipeline(&mut context) {

--- a/src/game/stage_repository.rs
+++ b/src/game/stage_repository.rs
@@ -20,7 +20,7 @@ pub enum GameMode {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DifficultyLevel {
     Easy,   // ~100 characters
     Normal, // ~200 characters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod cli;
 pub mod error;
 pub mod extractor;

--- a/src/models/challenge.rs
+++ b/src/models/challenge.rs
@@ -1,7 +1,7 @@
 use super::git_repository::GitRepository;
 use crate::game::DifficultyLevel;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Challenge {
     pub id: String,
     pub source_file_path: Option<String>,

--- a/src/models/git_repository.rs
+++ b/src/models/git_repository.rs
@@ -11,3 +11,62 @@ pub struct GitRepository {
     pub is_dirty: bool,
     pub root_path: Option<PathBuf>,
 }
+
+impl GitRepository {
+    /// Generate a cache key from the repository URL.
+    /// Supports multiple URL formats:
+    /// - https://github.com/owner/repo -> github_com_owner_repo
+    /// - git@github.com:owner/repo -> github_com_owner_repo
+    /// - ssh://git@github.com/owner/repo -> github_com_owner_repo
+    pub fn cache_key(&self) -> String {
+        Self::extract_cache_key(&self.remote_url)
+    }
+
+    fn extract_cache_key(repo_url: &str) -> String {
+        // Handle SSH format: git@host:owner/repo
+        if let Some(ssh_part) = repo_url.strip_prefix("git@") {
+            if let Some(colon_pos) = ssh_part.find(':') {
+                let host = &ssh_part[..colon_pos];
+                let path = &ssh_part[colon_pos + 1..];
+                let parts: Vec<&str> = path.split('/').collect();
+                if parts.len() >= 2 {
+                    let host_clean = host.replace('.', "_");
+                    let owner = parts[0];
+                    let repo = parts[1].trim_end_matches(".git");
+                    return format!("{}_{}_{}", host_clean, owner, repo);
+                }
+            }
+        }
+
+        // Handle ssh:// format: ssh://git@host/owner/repo
+        if let Some(ssh_url) = repo_url.strip_prefix("ssh://") {
+            if let Some(at_pos) = ssh_url.find('@') {
+                let host_path = &ssh_url[at_pos + 1..];
+                let parts: Vec<&str> = host_path.split('/').collect();
+                if parts.len() >= 3 {
+                    let host = parts[0].replace('.', "_");
+                    let owner = parts[1];
+                    let repo = parts[2].trim_end_matches(".git");
+                    return format!("{}_{}_{}", host, owner, repo);
+                }
+            }
+        }
+
+        // Handle HTTP(S) format: https://github.com/owner/repo
+        if let Some(url_without_protocol) = repo_url
+            .strip_prefix("https://")
+            .or_else(|| repo_url.strip_prefix("http://"))
+        {
+            let parts: Vec<&str> = url_without_protocol.split('/').collect();
+            if parts.len() >= 3 {
+                let host = parts[0].replace('.', "_");
+                let owner = parts[1];
+                let repo = parts[2].trim_end_matches(".git");
+                return format!("{}_{}_{}", host, owner, repo);
+            }
+        }
+
+        // Fallback for malformed URLs
+        repo_url.replace(['/', ':', '.'], "_")
+    }
+}

--- a/tests/unit/cache/challenge_cache_tests.rs
+++ b/tests/unit/cache/challenge_cache_tests.rs
@@ -1,0 +1,294 @@
+use gittype::cache::ChallengeCache;
+use gittype::models::{Challenge, GitRepository};
+use std::fs;
+use tempfile;
+
+fn create_test_repo_with_files(url: &str, commit: Option<String>, dirty: bool) -> GitRepository {
+    // Create a temporary directory for test files
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path().to_path_buf();
+
+    // Create test files
+    let test_file = temp_path.join("test.rs");
+    fs::write(
+        &test_file,
+        "// Test file\nfn main() {\n    println!(\"Hello, world!\");\n}",
+    )
+    .unwrap();
+
+    // Keep the temp directory alive by leaking it (for test purposes)
+    std::mem::forget(temp_dir);
+
+    GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: url.to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: commit,
+        is_dirty: dirty,
+        root_path: Some(temp_path),
+    }
+}
+
+fn create_test_challenge_with_file(id: &str, _repo: &GitRepository) -> Challenge {
+    let mut challenge = Challenge::new(
+        id.to_string(),
+        "// Test file\nfn main() {\n    println!(\"Hello, world!\");\n}".to_string(),
+    );
+    challenge.source_file_path = Some("test.rs".to_string());
+    challenge.start_line = Some(1);
+    challenge.end_line = Some(4);
+    challenge
+}
+
+fn create_test_cache() -> ChallengeCache {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path().to_path_buf();
+    std::mem::forget(temp_dir); // Keep alive for test duration
+
+    ChallengeCache::with_cache_dir(temp_path)
+}
+
+#[test]
+fn test_cache_save_and_load() {
+    let cache = create_test_cache();
+    let repo = create_test_repo_with_files(
+        "https://github.com/test/save-load",
+        Some("abc123".to_string()),
+        false,
+    );
+    let challenges = vec![
+        create_test_challenge_with_file("1", &repo),
+        create_test_challenge_with_file("2", &repo),
+    ];
+
+    // Clear any existing cache
+    let _ = cache.clear();
+
+    // Save challenges
+    let save_result = cache.save(&repo, &challenges);
+    assert!(save_result.is_ok());
+
+    // Load challenges
+    let loaded = cache.load_with_progress(&repo, None);
+    assert!(loaded.is_some());
+    let loaded_challenges = loaded.unwrap();
+    assert_eq!(loaded_challenges.len(), 2);
+    assert_eq!(loaded_challenges[0].id, "1");
+    assert_eq!(loaded_challenges[1].id, "2");
+}
+
+#[test]
+fn test_dirty_repository_skips_cache() {
+    let cache = create_test_cache();
+    let repo_clean = create_test_repo_with_files(
+        "https://github.com/test/dirty-test",
+        Some("abc123".to_string()),
+        false,
+    );
+    let repo_dirty = create_test_repo_with_files(
+        "https://github.com/test/dirty-test-dirty",
+        Some("abc123".to_string()),
+        true,
+    );
+    let challenges = vec![
+        create_test_challenge_with_file("1", &repo_clean),
+        create_test_challenge_with_file("2", &repo_clean),
+    ];
+
+    let _ = cache.clear();
+
+    // Clean repository should save to cache
+    let save_result = cache.save(&repo_clean, &challenges);
+    assert!(save_result.is_ok());
+
+    // Clean repository should load from cache
+    let loaded_clean = cache.load_with_progress(&repo_clean, None);
+    assert!(loaded_clean.is_some());
+    assert_eq!(loaded_clean.unwrap().len(), 2);
+
+    // Dirty repository should not load from cache (even with same commit)
+    let loaded_dirty = cache.load_with_progress(&repo_dirty, None);
+    assert!(loaded_dirty.is_none());
+}
+
+#[test]
+fn test_commit_hash_invalidation() {
+    let cache = create_test_cache();
+    let repo_v1 = create_test_repo_with_files(
+        "https://github.com/test/invalidation",
+        Some("abc123".to_string()),
+        false,
+    );
+    let repo_v2 = create_test_repo_with_files(
+        "https://github.com/test/invalidation2",
+        Some("def456".to_string()),
+        false,
+    );
+    let challenges_v1 = vec![
+        create_test_challenge_with_file("1", &repo_v1),
+        create_test_challenge_with_file("2", &repo_v1),
+    ];
+    let challenges_v2 = vec![
+        create_test_challenge_with_file("3", &repo_v2),
+        create_test_challenge_with_file("4", &repo_v2),
+    ];
+
+    let _ = cache.clear();
+
+    // Cache challenges for first commit
+    let save_result = cache.save(&repo_v1, &challenges_v1);
+    assert!(save_result.is_ok());
+
+    let loaded_v1 = cache.load_with_progress(&repo_v1, None);
+    assert!(loaded_v1.is_some());
+    assert_eq!(loaded_v1.unwrap().len(), 2);
+
+    // Different repository should not find cached data
+    let loaded_v2 = cache.load_with_progress(&repo_v2, None);
+    assert!(loaded_v2.is_none());
+
+    // Cache challenges for second repo
+    let save_result_v2 = cache.save(&repo_v2, &challenges_v2);
+    assert!(save_result_v2.is_ok());
+
+    // First repo should still be cached
+    let loaded_v1_after = cache.load_with_progress(&repo_v1, None);
+    assert!(loaded_v1_after.is_some());
+    assert_eq!(loaded_v1_after.unwrap().len(), 2);
+
+    // Second repo should be cached
+    let loaded_v2_after = cache.load_with_progress(&repo_v2, None);
+    assert!(loaded_v2_after.is_some());
+    assert_eq!(loaded_v2_after.unwrap().len(), 2);
+}
+
+#[test]
+fn test_cache_invalidation() {
+    let cache = create_test_cache();
+    let repo = create_test_repo_with_files(
+        "https://github.com/test/invalidate",
+        Some("test123".to_string()),
+        false,
+    );
+    let challenges = vec![
+        create_test_challenge_with_file("1", &repo),
+        create_test_challenge_with_file("2", &repo),
+    ];
+
+    let _ = cache.clear();
+
+    // Initially no cache
+    assert!(cache.load_with_progress(&repo, None).is_none());
+
+    // Save to cache
+    let save_result = cache.save(&repo, &challenges);
+    assert!(save_result.is_ok());
+
+    // Should be cached
+    let loaded = cache.load_with_progress(&repo, None);
+    assert!(loaded.is_some());
+    assert_eq!(loaded.unwrap().len(), 2);
+
+    // Invalidate cache for repo
+    let invalidated = cache.invalidate_repo(&repo);
+    assert!(invalidated.is_ok());
+    assert!(invalidated.unwrap());
+
+    // Should no longer be cached
+    assert!(cache.load_with_progress(&repo, None).is_none());
+}
+
+#[test]
+fn test_cache_stats_and_list() {
+    let cache = create_test_cache();
+    let _ = cache.clear();
+
+    // Initially empty
+    let stats = cache.stats();
+    assert!(stats.is_ok());
+    let (count, _size) = stats.unwrap();
+    assert_eq!(count, 0);
+
+    let repo = create_test_repo_with_files(
+        "https://github.com/test/stats",
+        Some("test123".to_string()),
+        false,
+    );
+    let challenges = vec![create_test_challenge_with_file("test", &repo)];
+    let _ = cache.save(&repo, &challenges);
+
+    // Should have one entry
+    let stats = cache.stats();
+    assert!(stats.is_ok());
+    let (count, _size) = stats.unwrap();
+    assert_eq!(count, 1);
+
+    // Check list keys
+    let keys = cache.list_keys();
+    assert!(keys.is_ok());
+    let keys = keys.unwrap();
+    assert_eq!(keys.len(), 1);
+    // Key format is now "github_com_test_stats:test123"
+    assert!(keys[0].contains("github_com"));
+    assert!(keys[0].contains("test"));
+    assert!(keys[0].contains("stats"));
+    assert!(keys[0].contains("test123"));
+}
+
+#[test]
+fn test_ssh_url_key_extraction() {
+    let cache = create_test_cache();
+
+    // Test git@ format
+    let repo_ssh = create_test_repo_with_files(
+        "git@github.com:owner/repo",
+        Some("abc123".to_string()),
+        false,
+    );
+    let challenges = vec![create_test_challenge_with_file("ssh_test", &repo_ssh)];
+
+    let _ = cache.clear();
+    let save_result = cache.save(&repo_ssh, &challenges);
+    assert!(save_result.is_ok());
+
+    // Test ssh:// format
+    let repo_ssh_protocol = create_test_repo_with_files(
+        "ssh://git@github.com/owner/repo",
+        Some("def456".to_string()),
+        false,
+    );
+
+    // Should use same cache key since it's the same repo
+    let loaded = cache.load_with_progress(&repo_ssh_protocol, None);
+    // Won't load due to different commit hash, but should not error
+    assert!(loaded.is_none());
+
+    // Test cache keys are generated consistently
+    let keys = cache.list_keys().unwrap();
+    assert_eq!(keys.len(), 1);
+    assert!(keys[0].contains("github_com_owner_repo"));
+}
+
+#[test]
+fn test_basic_cache_clear() {
+    let cache = create_test_cache();
+    let repo = create_test_repo_with_files(
+        "https://github.com/test/clear",
+        Some("test123".to_string()),
+        false,
+    );
+    let challenges = vec![create_test_challenge_with_file("test", &repo)];
+
+    // Save and verify
+    let _ = cache.save(&repo, &challenges);
+    assert!(cache.load_with_progress(&repo, None).is_some());
+
+    // Clear and verify
+    let clear_result = cache.clear();
+    assert!(clear_result.is_ok());
+
+    // Should be empty
+    let stats = cache.stats().unwrap();
+    assert_eq!(stats.0, 0);
+}

--- a/tests/unit/cache/mod.rs
+++ b/tests/unit/cache/mod.rs
@@ -1,0 +1,1 @@
+pub mod challenge_cache_tests;

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod error_tests;
 pub mod extractor_unit_tests;
 pub mod game;

--- a/tests/unit/models/git_repository_tests.rs
+++ b/tests/unit/models/git_repository_tests.rs
@@ -18,3 +18,86 @@ fn git_repository_equality_depends_on_all_fields() {
     same.is_dirty = true;
     assert_ne!(repo, same);
 }
+
+#[test]
+fn test_cache_key_https_url() {
+    let repo = GitRepository {
+        user_name: "user".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/owner/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc123".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    assert_eq!(repo.cache_key(), "github_com_owner_repo");
+}
+
+#[test]
+fn test_cache_key_ssh_url() {
+    let repo = GitRepository {
+        user_name: "user".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "git@github.com:owner/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc123".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    assert_eq!(repo.cache_key(), "github_com_owner_repo");
+}
+
+#[test]
+fn test_cache_key_ssh_protocol_url() {
+    let repo = GitRepository {
+        user_name: "user".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "ssh://git@github.com/owner/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc123".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    assert_eq!(repo.cache_key(), "github_com_owner_repo");
+}
+
+#[test]
+fn test_cache_key_with_git_suffix() {
+    let repo = GitRepository {
+        user_name: "user".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/owner/repo.git".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc123".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    assert_eq!(repo.cache_key(), "github_com_owner_repo");
+}
+
+#[test]
+fn test_cache_key_different_hosts() {
+    let github_repo = GitRepository {
+        user_name: "user".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/owner/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc123".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+
+    let gitlab_repo = GitRepository {
+        user_name: "user".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://gitlab.com/owner/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc123".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+
+    assert_eq!(github_repo.cache_key(), "github_com_owner_repo");
+    assert_eq!(gitlab_repo.cache_key(), "gitlab_com_owner_repo");
+    assert_ne!(github_repo.cache_key(), gitlab_repo.cache_key());
+}


### PR DESCRIPTION
## Summary
- Add persistent disk-based cache for challenges to improve loading performance 
- Cache challenges to ~/.gittype/cache/ using binary format with gzip compression
- Generate cache keys from repository URLs (supports HTTPS, SSH, git@ formats)
- Store challenge pointers (file paths + line numbers) instead of full code content
- Enable cache checking step that allows early pipeline termination on cache hits

## Test plan
- [x] All existing tests pass
- [x] Added comprehensive test coverage for cache functionality
- [x] Cache stats, clear, and list CLI commands work correctly
- [x] Cache properly invalidates on commit hash changes
- [x] Cache skips dirty repositories as expected

Closes #109

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Persistent local challenge cache for faster startups: generated results are saved and auto-loaded when valid, skipping redundant processing.
  - New CLI commands: gittype cache stats, gittype cache clear, and gittype cache list.
  - Loading sequence now checks cache and skips intermediate steps when a valid cache is used.

- **Chores**
  - Added dependencies to enable compressed binary caching and (de)serialization support.
  - Exposed a new cache module at the crate root.

- **Tests**
  - Added unit tests for cache save/load, dirty/commit invalidation, stats/listing, cache clearing, and cache key extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->