### PR TITLE
feat: add color-coded language display in typing interface

### DIFF
--- a/src/extractor/models/languages/c.rs
+++ b/src/extractor/models/languages/c.rs
@@ -11,4 +11,13 @@ impl Language for C {
     fn extensions(&self) -> Vec<&'static str> {
         vec!["c", "h"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_C
+    }
+
+    fn display_name(&self) -> &'static str {
+        "C"
+    }
 }

--- a/src/extractor/models/languages/cpp.rs
+++ b/src/extractor/models/languages/cpp.rs
@@ -14,4 +14,13 @@ impl Language for Cpp {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["c++"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_CPP
+    }
+
+    fn display_name(&self) -> &'static str {
+        "C++"
+    }
 }

--- a/src/extractor/models/languages/csharp.rs
+++ b/src/extractor/models/languages/csharp.rs
@@ -14,4 +14,13 @@ impl Language for CSharp {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["cs", "c#"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_CSHARP
+    }
+
+    fn display_name(&self) -> &'static str {
+        "C#"
+    }
 }

--- a/src/extractor/models/languages/dart.rs
+++ b/src/extractor/models/languages/dart.rs
@@ -11,4 +11,13 @@ impl Language for Dart {
     fn extensions(&self) -> Vec<&'static str> {
         vec!["dart"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_DART
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Dart"
+    }
 }

--- a/src/extractor/models/languages/go.rs
+++ b/src/extractor/models/languages/go.rs
@@ -11,4 +11,13 @@ impl Language for Go {
     fn extensions(&self) -> Vec<&'static str> {
         vec!["go"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_GO
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Go"
+    }
 }

--- a/src/extractor/models/languages/haskell.rs
+++ b/src/extractor/models/languages/haskell.rs
@@ -14,4 +14,13 @@ impl Language for Haskell {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["hs"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_HASKELL
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Haskell"
+    }
 }

--- a/src/extractor/models/languages/java.rs
+++ b/src/extractor/models/languages/java.rs
@@ -11,4 +11,13 @@ impl Language for Java {
     fn extensions(&self) -> Vec<&'static str> {
         vec!["java"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_JAVA
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Java"
+    }
 }

--- a/src/extractor/models/languages/javascript.rs
+++ b/src/extractor/models/languages/javascript.rs
@@ -14,4 +14,13 @@ impl Language for JavaScript {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["js"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_JAVASCRIPT
+    }
+
+    fn display_name(&self) -> &'static str {
+        "JavaScript"
+    }
 }

--- a/src/extractor/models/languages/kotlin.rs
+++ b/src/extractor/models/languages/kotlin.rs
@@ -14,4 +14,13 @@ impl Language for Kotlin {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["kt"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_KOTLIN
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Kotlin"
+    }
 }

--- a/src/extractor/models/languages/php.rs
+++ b/src/extractor/models/languages/php.rs
@@ -11,4 +11,13 @@ impl Language for Php {
     fn extensions(&self) -> Vec<&'static str> {
         vec!["php", "phtml", "php3", "php4", "php5"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_PHP
+    }
+
+    fn display_name(&self) -> &'static str {
+        "PHP"
+    }
 }

--- a/src/extractor/models/languages/python.rs
+++ b/src/extractor/models/languages/python.rs
@@ -14,4 +14,13 @@ impl Language for Python {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["py"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_PYTHON
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Python"
+    }
 }

--- a/src/extractor/models/languages/ruby.rs
+++ b/src/extractor/models/languages/ruby.rs
@@ -14,4 +14,13 @@ impl Language for Ruby {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["rb"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_RUBY
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Ruby"
+    }
 }

--- a/src/extractor/models/languages/rust.rs
+++ b/src/extractor/models/languages/rust.rs
@@ -14,4 +14,13 @@ impl Language for Rust {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["rs"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_RUST
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Rust"
+    }
 }

--- a/src/extractor/models/languages/scala.rs
+++ b/src/extractor/models/languages/scala.rs
@@ -14,4 +14,13 @@ impl Language for Scala {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["sc"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_SCALA
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Scala"
+    }
 }

--- a/src/extractor/models/languages/swift.rs
+++ b/src/extractor/models/languages/swift.rs
@@ -11,4 +11,13 @@ impl Language for Swift {
     fn extensions(&self) -> Vec<&'static str> {
         vec!["swift"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_SWIFT
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Swift"
+    }
 }

--- a/src/extractor/models/languages/typescript.rs
+++ b/src/extractor/models/languages/typescript.rs
@@ -14,4 +14,13 @@ impl Language for TypeScript {
     fn aliases(&self) -> Vec<&'static str> {
         vec!["ts"]
     }
+
+    fn color(&self) -> ratatui::style::Color {
+        use crate::ui::Colors;
+        Colors::LANG_TYPESCRIPT
+    }
+
+    fn display_name(&self) -> &'static str {
+        "TypeScript"
+    }
 }

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -54,6 +54,25 @@ impl Colors {
     // Progress bar colors
     pub const PROGRESS_BAR: Color = Color::Cyan;
     pub const PROGRESS_BG: Color = Color::DarkGray;
+
+    // Programming language colors - distinct and accessible
+    pub const LANG_RUST: Color = Color::Rgb(222, 165, 132); // Rust orange
+    pub const LANG_PYTHON: Color = Color::Rgb(255, 212, 59); // Python yellow
+    pub const LANG_JAVASCRIPT: Color = Color::Rgb(240, 219, 79); // JS yellow
+    pub const LANG_TYPESCRIPT: Color = Color::Rgb(49, 120, 198); // TS blue
+    pub const LANG_GO: Color = Color::Rgb(0, 173, 181); // Go cyan
+    pub const LANG_JAVA: Color = Color::Rgb(237, 41, 57); // Java red
+    pub const LANG_C: Color = Color::Rgb(85, 85, 85); // C gray
+    pub const LANG_CPP: Color = Color::Rgb(0, 89, 156); // C++ blue
+    pub const LANG_CSHARP: Color = Color::Rgb(239, 117, 27); // C# orange
+    pub const LANG_PHP: Color = Color::Rgb(119, 123, 180); // PHP purple
+    pub const LANG_RUBY: Color = Color::Rgb(204, 52, 45); // Ruby red
+    pub const LANG_SWIFT: Color = Color::Rgb(250, 109, 63); // Swift orange
+    pub const LANG_KOTLIN: Color = Color::Rgb(124, 75, 255); // Kotlin purple
+    pub const LANG_SCALA: Color = Color::Rgb(220, 50, 47); // Scala red
+    pub const LANG_HASKELL: Color = Color::Rgb(94, 80, 134); // Haskell purple
+    pub const LANG_DART: Color = Color::Rgb(0, 180, 240); // Dart blue
+    pub const LANG_DEFAULT: Color = Color::White; // Default for unknown languages
 }
 
 impl Colors {

--- a/tests/unit/extractor/language_tests.rs
+++ b/tests/unit/extractor/language_tests.rs
@@ -1,0 +1,67 @@
+use gittype::extractor::models::language::LanguageRegistry;
+use gittype::ui::Colors;
+
+#[test]
+fn language_registry_get_color_returns_specific_colors_for_known_languages() {
+    assert_eq!(LanguageRegistry::get_color(Some("rust")), Colors::LANG_RUST);
+    assert_eq!(LanguageRegistry::get_color(Some("python")), Colors::LANG_PYTHON);
+    assert_eq!(LanguageRegistry::get_color(Some("javascript")), Colors::LANG_JAVASCRIPT);
+    assert_eq!(LanguageRegistry::get_color(Some("typescript")), Colors::LANG_TYPESCRIPT);
+}
+
+#[test]
+fn language_registry_get_color_returns_default_for_unknown_languages() {
+    assert_eq!(LanguageRegistry::get_color(Some("unknown")), Colors::LANG_DEFAULT);
+    assert_eq!(LanguageRegistry::get_color(Some("xyz")), Colors::LANG_DEFAULT);
+    assert_eq!(LanguageRegistry::get_color(Some("")), Colors::LANG_DEFAULT);
+}
+
+#[test]
+fn language_registry_get_color_returns_default_for_none() {
+    assert_eq!(LanguageRegistry::get_color(None), Colors::LANG_DEFAULT);
+}
+
+#[test]
+fn language_registry_get_display_name_returns_formal_names() {
+    assert_eq!(LanguageRegistry::get_display_name(Some("rust")), "Rust");
+    assert_eq!(LanguageRegistry::get_display_name(Some("python")), "Python");
+    assert_eq!(LanguageRegistry::get_display_name(Some("javascript")), "JavaScript");
+    assert_eq!(LanguageRegistry::get_display_name(Some("typescript")), "TypeScript");
+    assert_eq!(LanguageRegistry::get_display_name(Some("cpp")), "C++");
+    assert_eq!(LanguageRegistry::get_display_name(Some("csharp")), "C#");
+}
+
+#[test]
+fn language_registry_get_display_name_is_case_insensitive() {
+    assert_eq!(LanguageRegistry::get_display_name(Some("RUST")), "Rust");
+    assert_eq!(LanguageRegistry::get_display_name(Some("JavaScript")), "JavaScript");
+    assert_eq!(LanguageRegistry::get_display_name(Some("Python")), "Python");
+}
+
+#[test]
+fn language_registry_get_display_name_preserves_unknown_languages() {
+    assert_eq!(LanguageRegistry::get_display_name(Some("unknown")), "unknown");
+    assert_eq!(LanguageRegistry::get_display_name(Some("CustomLang")), "CustomLang");
+}
+
+#[test]
+fn language_registry_get_display_name_returns_unknown_for_none() {
+    assert_eq!(LanguageRegistry::get_display_name(None), "Unknown");
+}
+
+#[test]
+fn language_registry_get_by_name_finds_known_languages() {
+    assert!(LanguageRegistry::get_by_name("rust").is_some());
+    assert!(LanguageRegistry::get_by_name("python").is_some());
+    assert!(LanguageRegistry::get_by_name("javascript").is_some());
+    assert!(LanguageRegistry::get_by_name("unknown").is_none());
+}
+
+#[test]
+fn language_trait_methods_work_correctly() {
+    if let Some(rust_lang) = LanguageRegistry::get_by_name("rust") {
+        assert_eq!(rust_lang.name(), "rust");
+        assert_eq!(rust_lang.display_name(), "Rust");
+        assert_eq!(rust_lang.color(), Colors::LANG_RUST);
+    }
+}

--- a/tests/unit/extractor/mod.rs
+++ b/tests/unit/extractor/mod.rs
@@ -1,0 +1,1 @@
+mod language_tests;


### PR DESCRIPTION
## Summary
This PR implements issue #232 by adding color-coded language display in the typing interface and ensures consistent language naming across the application.

### Changes
- Add polymorphic `color()` and `display_name()` methods to the `Language` trait
- Implement these methods for all 16 supported languages with distinct RGB colors
- Add 16 language-specific color constants to the `Colors` module
- Update `TypingHeaderView` to display colored language names before difficulty level
- Use square brackets `[]` instead of parentheses for consistency
- Add helper methods to `LanguageRegistry` for retrieving language colors and display names
- **NEW**: Update Analytics Screen to use formal language names (display_name) instead of raw names

### Visual Changes
- Language names now appear with distinct colors (e.g., Rust in orange, Python in yellow)
- Languages are displayed with formal names everywhere:
  - Typing interface: "JavaScript" not "js", "C++" not "cpp"
  - Analytics screen: consistent formal naming in language lists and details
- Display order in typing header: `Title [Language] [Difficulty]`

### Technical Details
- Uses trait-based polymorphism for extensible color/display name system
- RGB color values chosen for accessibility and visual distinction
- Maintains backward compatibility with existing language detection
- Consistent language display across typing and analytics screens

close: #232

🤖 Generated with [Claude Code](https://claude.ai/code)