### PR TITLE
Add repository management commands with enhanced UI

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -75,6 +75,11 @@ pub enum Commands {
         #[command(subcommand)]
         cache_command: CacheCommands,
     },
+    /// Manage repositories
+    Repo {
+        #[command(subcommand)]
+        repo_command: RepoCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -85,4 +90,17 @@ pub enum CacheCommands {
     Clear,
     /// List cached repository keys
     List,
+}
+#[derive(Subcommand)]
+pub enum RepoCommands {
+    /// List all cached repositories
+    List,
+    /// Clear all cached repositories
+    Clear {
+        /// Force clear without confirmation
+        #[arg(long)]
+        force: bool,
+    },
+    /// Play a cached repository interactively
+    Play,
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,9 +1,11 @@
 pub mod export;
 pub mod game;
 pub mod history;
+pub mod repo;
 pub mod stats;
 
 pub use export::run_export;
 pub use game::run_game_session;
 pub use history::run_history;
+pub use repo::{run_repo_clear, run_repo_list, run_repo_play};
 pub use stats::run_stats;

--- a/src/cli/commands/repo.rs
+++ b/src/cli/commands/repo.rs
@@ -1,0 +1,141 @@
+use crate::storage::daos::RepositoryDao;
+use crate::storage::Database;
+use crate::Result;
+use std::io::{self, Write};
+
+pub fn run_repo_list() -> Result<()> {
+    use crate::cli::views::repo_list_view;
+
+    let db = Database::new()?;
+    let repo_dao = RepositoryDao::new(&db);
+
+    let repositories = repo_dao.get_all_repositories_with_languages()?;
+
+    if repositories.is_empty() {
+        println!("No played repositories found.");
+        println!("Try running `gittype --repo owner/repo` to cache a repository first.");
+        return Ok(());
+    }
+
+    repo_list_view::render_repo_list(repositories)
+}
+
+pub fn run_repo_clear(force: bool) -> Result<()> {
+    use std::fs;
+
+    // Get the repos directory path
+    let home_dir = dirs::home_dir().ok_or_else(|| {
+        crate::error::GitTypeError::InvalidRepositoryFormat(
+            "Could not determine home directory".to_string(),
+        )
+    })?;
+    let repos_dir = home_dir.join(".gittype").join("repos");
+
+    if !repos_dir.exists() {
+        println!("No cached repositories directory found.");
+        return Ok(());
+    }
+
+    // Count actual repositories (look for directories with .git subdirectories)
+    fn count_git_repositories(path: &std::path::Path) -> usize {
+        let mut count = 0;
+        if let Ok(entries) = fs::read_dir(path) {
+            for entry in entries.flatten() {
+                let entry_path = entry.path();
+                if entry_path.is_dir() {
+                    // Check if this directory contains a .git subdirectory (actual repo)
+                    if entry_path.join(".git").exists() {
+                        count += 1;
+                    } else {
+                        // Recursively check subdirectories
+                        count += count_git_repositories(&entry_path);
+                    }
+                }
+            }
+        }
+        count
+    }
+
+    let cached_count = count_git_repositories(&repos_dir);
+
+    if cached_count == 0 {
+        println!("No cached repositories found.");
+        return Ok(());
+    }
+
+    if !force {
+        println!("This will delete all locally cached repositories in:");
+        println!("  {}", repos_dir.display());
+        println!("({} cached repositories will be removed)", cached_count);
+
+        print!("Are you sure you want to continue? [y/N]: ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        let input = input.trim().to_lowercase();
+        if input != "y" && input != "yes" {
+            println!("Operation cancelled.");
+            return Ok(());
+        }
+    }
+
+    // Delete the entire repos directory
+    match fs::remove_dir_all(&repos_dir) {
+        Ok(_) => {
+            println!("Successfully deleted all cached repositories.");
+            println!("Cache directory {} has been removed.", repos_dir.display());
+        }
+        Err(e) => {
+            return Err(crate::error::GitTypeError::InvalidRepositoryFormat(
+                format!("Failed to delete cache directory: {}", e),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn run_repo_play() -> Result<()> {
+    use crate::cli::views::repo_play_view;
+
+    let db = Database::new()?;
+    let repo_dao = RepositoryDao::new(&db);
+
+    let repositories = repo_dao.get_all_repositories_with_languages()?;
+
+    if repositories.is_empty() {
+        println!("No repositories found in cache.");
+        println!("Try running `gittype --repo owner/repo` to cache a repository first.");
+        return Ok(());
+    }
+
+    match repo_play_view::render_repo_play_ui(repositories.clone())? {
+        Some(selection) => {
+            let selected_repo = &repositories[selection];
+            let repo_spec = format!(
+                "{}/{}",
+                selected_repo.user_name, selected_repo.repository_name
+            );
+
+            println!("Starting gittype with repository: {}", repo_spec);
+
+            // Create a Cli struct to pass to run_game_session
+            let cli = crate::cli::args::Cli {
+                repo_path: None,
+                repo: Some(repo_spec),
+                langs: None,
+                config: None,
+                command: None,
+            };
+
+            // Start the game session
+            crate::cli::commands::run_game_session(cli)
+        }
+        None => {
+            println!("Repository selection cancelled.");
+            Ok(())
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod args;
 pub mod commands;
 pub mod runner;
+pub mod views;
 
 pub use args::{Cli, Commands};
 pub use runner::run_cli;

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -1,5 +1,8 @@
-use crate::cli::args::{CacheCommands, Cli, Commands};
-use crate::cli::commands::{run_export, run_game_session, run_history, run_stats};
+use crate::cli::args::{CacheCommands, Cli, Commands, RepoCommands};
+use crate::cli::commands::{
+    run_export, run_game_session, run_history, run_repo_clear, run_repo_list, run_repo_play,
+    run_stats,
+};
 use crate::logging::{setup_console_logging, setup_logging};
 use crate::Result;
 
@@ -16,6 +19,7 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
         Some(Commands::Stats) => run_stats(),
         Some(Commands::Export { format, output }) => run_export(format.clone(), output.clone()),
         Some(Commands::Cache { cache_command }) => run_cache_command(cache_command),
+        Some(Commands::Repo { repo_command }) => run_repo_command(repo_command),
         None => run_game_session(cli),
     }
 }
@@ -81,4 +85,12 @@ fn run_cache_command(cache_command: &CacheCommands) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn run_repo_command(repo_command: &RepoCommands) -> Result<()> {
+    match repo_command {
+        RepoCommands::List => run_repo_list(),
+        RepoCommands::Clear { force } => run_repo_clear(*force),
+        RepoCommands::Play => run_repo_play(),
+    }
 }

--- a/src/cli/views/mod.rs
+++ b/src/cli/views/mod.rs
@@ -1,0 +1,3 @@
+pub mod repo_list_view;
+pub mod repo_play_view;
+mod repo_utils;

--- a/src/cli/views/repo_list_view.rs
+++ b/src/cli/views/repo_list_view.rs
@@ -1,0 +1,221 @@
+use super::repo_utils;
+use crate::extractor::models::language::LanguageRegistry;
+use crate::storage::daos::repository_dao::StoredRepositoryWithLanguages;
+use crate::ui::colors::Colors;
+use crate::Result;
+use crossterm::{
+    execute,
+    style::{Color, ResetColor, SetForegroundColor},
+};
+use ratatui::{
+    backend::TestBackend,
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Padding, Paragraph},
+    Terminal,
+};
+use std::io::stdout;
+
+pub fn render_repo_list(repositories: Vec<StoredRepositoryWithLanguages>) -> Result<()> {
+    // Calculate terminal dimensions
+    let width = 120;
+    let height = repositories.len() as u16 + 10; // Extra space for headers and borders
+
+    // Create test backend to render widgets to buffer
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend)?;
+
+    terminal.draw(|f| {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Header
+                Constraint::Length(1), // Spacer
+                Constraint::Length(1), // Cache info
+                Constraint::Length(1), // Spacer
+                Constraint::Min(1),    // Repository list
+                Constraint::Length(3), // Legend
+            ])
+            .split(f.area());
+
+        // Main header
+        let header_line = Line::from(vec![Span::styled(
+            "GitType - Played Repositories",
+            Style::default()
+                .fg(Colors::INFO)
+                .add_modifier(Modifier::BOLD),
+        )]);
+        let header = Paragraph::new(header_line)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Colors::BORDER)),
+            );
+        f.render_widget(header, chunks[0]);
+
+        // Cache directory info
+        let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+        let cache_dir = home_dir.join(".gittype").join("repos");
+        let cache_line = Line::from(vec![
+            Span::styled("Cache Directory: ", Style::default().fg(Colors::MUTED)),
+            Span::styled(
+                cache_dir.to_string_lossy().to_string(),
+                Style::default().fg(Colors::TEXT),
+            ),
+        ]);
+        let cache_info = Paragraph::new(cache_line).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Colors::BORDER)),
+        );
+        f.render_widget(cache_info, chunks[2]);
+
+        // Repository list
+        let repo_width = 35;
+        let lang_width = 25;
+
+        let items: Vec<ListItem> = repositories
+            .iter()
+            .map(|repo| {
+                let repo_name = format!("{}/{}", repo.user_name, repo.repository_name);
+                let is_cached = repo_utils::is_repository_cached(&repo.remote_url);
+                let cache_indicator = if is_cached { "●" } else { "○" };
+
+                // Convert various git URL formats to HTTP URLs
+                let url = repo_utils::format_http_url(&repo.remote_url);
+
+                let mut line_spans = vec![
+                    Span::styled(
+                        format!("{} ", cache_indicator),
+                        Style::default().fg(if is_cached {
+                            Colors::SUCCESS
+                        } else {
+                            Colors::MUTED
+                        }),
+                    ),
+                    Span::styled(
+                        format!("{:<width$}", repo_name, width = repo_width),
+                        Style::default()
+                            .fg(Colors::TEXT)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ];
+
+                // Add language spans with proper color but fixed total width
+                if repo.languages.is_empty() {
+                    line_spans.push(Span::styled(
+                        format!("{:<width$}", "No challenges", width = lang_width),
+                        Style::default().fg(Colors::MUTED),
+                    ));
+                } else {
+                    let mut current_length = 0;
+                    for (i, lang) in repo.languages.iter().enumerate() {
+                        if i > 0 {
+                            if current_length + 2 <= lang_width {
+                                line_spans
+                                    .push(Span::styled(", ", Style::default().fg(Colors::MUTED)));
+                                current_length += 2;
+                            } else {
+                                break;
+                            }
+                        }
+                        let lang_name = LanguageRegistry::get_display_name(Some(lang));
+                        if current_length + lang_name.len() <= lang_width {
+                            line_spans.push(Span::styled(
+                                lang_name.clone(),
+                                Style::default().fg(LanguageRegistry::get_color(Some(lang))),
+                            ));
+                            current_length += lang_name.len();
+                        } else if current_length + 3 <= lang_width {
+                            line_spans
+                                .push(Span::styled("...", Style::default().fg(Colors::MUTED)));
+                            current_length += 3;
+                            break;
+                        } else {
+                            break;
+                        }
+                    }
+                    // Pad to fixed width
+                    if current_length < lang_width {
+                        line_spans.push(Span::raw(" ".repeat(lang_width - current_length)));
+                    }
+                }
+
+                line_spans.push(Span::styled(" ", Style::default()));
+                line_spans.push(Span::styled(url, Style::default().fg(Colors::MUTED)));
+
+                ListItem::new(Line::from(line_spans))
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Colors::BORDER))
+                    .title("Repository List")
+                    .title_style(
+                        Style::default()
+                            .fg(Colors::TEXT)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .padding(Padding::horizontal(1)),
+            )
+            .style(Style::default().fg(Colors::TEXT));
+        f.render_widget(list, chunks[4]);
+
+        // Legend
+        let legend_line = Line::from(vec![
+            Span::styled("●", Style::default().fg(Colors::SUCCESS)),
+            Span::styled(" Cached  ", Style::default().fg(Colors::TEXT)),
+            Span::styled("○", Style::default().fg(Colors::MUTED)),
+            Span::styled(" Not Cached", Style::default().fg(Colors::TEXT)),
+        ]);
+        let legend = Paragraph::new(legend_line)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Colors::BORDER)),
+            );
+        f.render_widget(legend, chunks[5]);
+    })?;
+
+    // Convert buffer to string and print with colors
+    let buffer = terminal.backend().buffer();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            let cell = &buffer[(x, y)];
+            // Convert ratatui color to crossterm and print
+            let fg_color = match cell.fg {
+                ratatui::style::Color::Green => Color::Green,
+                ratatui::style::Color::Red => Color::Red,
+                ratatui::style::Color::Yellow => Color::Yellow,
+                ratatui::style::Color::Blue => Color::Blue,
+                ratatui::style::Color::Magenta => Color::Magenta,
+                ratatui::style::Color::Cyan => Color::Cyan,
+                ratatui::style::Color::White => Color::White,
+                ratatui::style::Color::Black => Color::Black,
+                ratatui::style::Color::DarkGray => Color::DarkGrey,
+                ratatui::style::Color::LightRed => Color::DarkRed,
+                ratatui::style::Color::LightGreen => Color::DarkGreen,
+                ratatui::style::Color::LightYellow => Color::DarkYellow,
+                ratatui::style::Color::LightBlue => Color::DarkBlue,
+                ratatui::style::Color::LightMagenta => Color::DarkMagenta,
+                ratatui::style::Color::LightCyan => Color::DarkCyan,
+                ratatui::style::Color::Gray => Color::Grey,
+                ratatui::style::Color::Rgb(r, g, b) => Color::Rgb { r, g, b },
+                ratatui::style::Color::Indexed(i) => Color::AnsiValue(i),
+                ratatui::style::Color::Reset => Color::Reset,
+            };
+            execute!(stdout(), SetForegroundColor(fg_color))?;
+            print!("{}", cell.symbol());
+            execute!(stdout(), ResetColor)?;
+        }
+        println!();
+    }
+
+    Ok(())
+}

--- a/src/cli/views/repo_play_view.rs
+++ b/src/cli/views/repo_play_view.rs
@@ -1,0 +1,202 @@
+use super::repo_utils;
+use crate::extractor::models::language::LanguageRegistry;
+use crate::storage::daos::repository_dao::StoredRepositoryWithLanguages;
+use crate::ui::colors::Colors;
+use crate::Result;
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Padding, Paragraph},
+    Terminal,
+};
+use std::io;
+
+pub fn render_repo_play_ui(
+    repositories: Vec<StoredRepositoryWithLanguages>,
+) -> Result<Option<usize>> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // State for list selection
+    let mut list_state = ListState::default();
+    list_state.select(Some(0));
+
+    let result: Result<Option<usize>> = loop {
+        terminal.draw(|f| {
+            // Add horizontal padding like history_screen
+            let outer_chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Length(2), // Left padding
+                    Constraint::Min(1),    // Main content
+                    Constraint::Length(2), // Right padding
+                ])
+                .split(f.area());
+
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(3), // Header
+                    Constraint::Min(1),    // Repository list
+                    Constraint::Length(1), // Controls at bottom
+                ])
+                .split(outer_chunks[1]);
+
+            // Header - simplified like history_screen
+            let header_lines = vec![Line::from(vec![
+                Span::raw("  "), // Left padding
+                Span::styled(
+                    "Select Repository to Play",
+                    Style::default()
+                        .fg(Colors::INFO)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ])];
+
+            let header = Paragraph::new(header_lines).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Colors::BORDER))
+                    .title("GitType"),
+            );
+            f.render_widget(header, chunks[0]);
+
+            // Repository list
+            let items: Vec<ListItem> = repositories
+                .iter()
+                .map(|repo| {
+                    let repo_name = format!("{}/{}", repo.user_name, repo.repository_name);
+                    let is_cached = repo_utils::is_repository_cached(&repo.remote_url);
+                    let cache_indicator = if is_cached { "●" } else { "○" };
+                    let cache_color = if is_cached {
+                        Colors::SUCCESS
+                    } else {
+                        Colors::MUTED
+                    };
+
+                    let language_spans = if repo.languages.is_empty() {
+                        vec![Span::styled(
+                            "No challenges",
+                            Style::default().fg(Colors::MUTED),
+                        )]
+                    } else {
+                        let mut spans = Vec::new();
+                        for (i, lang) in repo.languages.iter().enumerate() {
+                            if i > 0 {
+                                spans.push(Span::styled(", ", Style::default().fg(Colors::MUTED)));
+                            }
+                            spans.push(Span::styled(
+                                LanguageRegistry::get_display_name(Some(lang)),
+                                Style::default().fg(LanguageRegistry::get_color(Some(lang))),
+                            ));
+                        }
+                        spans
+                    };
+
+                    let mut line_spans = vec![
+                        Span::raw("  "), // Left padding for list items
+                        Span::styled(cache_indicator, Style::default().fg(cache_color)),
+                        Span::raw(" "),
+                        Span::styled(
+                            format!("{:<32}", repo_name),
+                            Style::default()
+                                .fg(Colors::TEXT)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw(" "),
+                    ];
+                    line_spans.extend(language_spans);
+
+                    ListItem::new(Line::from(line_spans))
+                })
+                .collect();
+
+            let list = List::new(items)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Colors::BORDER))
+                        .title("Played Repositories")
+                        .title_style(
+                            Style::default()
+                                .fg(Colors::TEXT)
+                                .add_modifier(Modifier::BOLD),
+                        )
+                        .padding(Padding::uniform(1)),
+                )
+                .style(Style::default().fg(Colors::TEXT))
+                .highlight_style(
+                    Style::default()
+                        .bg(Colors::MUTED)
+                        .add_modifier(Modifier::BOLD),
+                );
+            f.render_stateful_widget(list, chunks[1], &mut list_state);
+
+            // Controls at bottom - using semantic color for navigation keys
+            let controls_line = Line::from(vec![
+                Span::styled("[↑↓/JK]", Style::default().fg(Colors::NAVIGATION_KEY)),
+                Span::styled(" Navigate  ", Style::default().fg(Colors::TEXT)),
+                Span::styled("[SPACE]", Style::default().fg(Colors::SUCCESS)),
+                Span::styled(" Play  ", Style::default().fg(Colors::TEXT)),
+                Span::styled("[ESC]", Style::default().fg(Colors::BACK_KEY)),
+                Span::styled(" Return  ", Style::default().fg(Colors::TEXT)),
+                Span::styled("●", Style::default().fg(Colors::SUCCESS)),
+                Span::styled(" Cached ", Style::default().fg(Colors::TEXT)),
+                Span::styled("○", Style::default().fg(Colors::MUTED)),
+                Span::styled(" Not Cached", Style::default().fg(Colors::TEXT)),
+            ]);
+            let controls = Paragraph::new(controls_line).alignment(Alignment::Center);
+            f.render_widget(controls, chunks[2]);
+        })?;
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Press {
+                match key.code {
+                    KeyCode::Esc => break Ok(None),
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if let Some(selected) = list_state.selected() {
+                            if selected < repositories.len() - 1 {
+                                list_state.select(Some(selected + 1));
+                            }
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        if let Some(selected) = list_state.selected() {
+                            if selected > 0 {
+                                list_state.select(Some(selected - 1));
+                            }
+                        }
+                    }
+                    KeyCode::Char(' ') => {
+                        if let Some(selected) = list_state.selected() {
+                            break Ok(Some(selected));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    result
+}

--- a/src/cli/views/repo_utils.rs
+++ b/src/cli/views/repo_utils.rs
@@ -1,0 +1,76 @@
+use crate::repository_manager::{RepoInfo, RepositoryManager};
+
+/// Extract host, owner, and repository name from a git URL
+fn parse_git_url(remote_url: &str) -> Option<(String, String, String)> {
+    // Handle SSH format: git@host:owner/repo
+    if let Some(ssh_part) = remote_url.strip_prefix("git@") {
+        if let Some(colon_pos) = ssh_part.find(':') {
+            let host = &ssh_part[..colon_pos];
+            let path = &ssh_part[colon_pos + 1..];
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() >= 2 {
+                let owner = parts[0];
+                let repo = parts[1].trim_end_matches(".git");
+                return Some((host.to_string(), owner.to_string(), repo.to_string()));
+            }
+        }
+    }
+
+    // Handle ssh:// format: ssh://git@host/owner/repo
+    if let Some(ssh_url) = remote_url.strip_prefix("ssh://") {
+        if let Some(at_pos) = ssh_url.find('@') {
+            let host_path = &ssh_url[at_pos + 1..];
+            let parts: Vec<&str> = host_path.split('/').collect();
+            if parts.len() >= 3 {
+                let host = parts[0];
+                let owner = parts[1];
+                let repo = parts[2].trim_end_matches(".git");
+                return Some((host.to_string(), owner.to_string(), repo.to_string()));
+            }
+        }
+    }
+
+    // Handle HTTP(S) format: https://host/owner/repo
+    if let Some(url_without_protocol) = remote_url
+        .strip_prefix("https://")
+        .or_else(|| remote_url.strip_prefix("http://"))
+    {
+        let parts: Vec<&str> = url_without_protocol.split('/').collect();
+        if parts.len() >= 3 {
+            let host = parts[0];
+            let owner = parts[1];
+            let repo = parts[2].trim_end_matches(".git");
+            return Some((host.to_string(), owner.to_string(), repo.to_string()));
+        }
+    }
+
+    None
+}
+
+/// Convert various git URL formats to HTTP URLs
+pub fn format_http_url(remote_url: &str) -> String {
+    if let Some((host, owner, repo)) = parse_git_url(remote_url) {
+        format!("https://{}/{}/{}", host, owner, repo)
+    } else {
+        // Fallback: return as-is
+        remote_url.to_string()
+    }
+}
+
+/// Check if a repository is cached locally
+pub fn is_repository_cached(remote_url: &str) -> bool {
+    if let Some((host, owner, repo)) = parse_git_url(remote_url) {
+        let repo_info = RepoInfo {
+            origin: host,
+            owner,
+            name: repo,
+        };
+
+        match RepositoryManager::get_local_repo_path(&repo_info) {
+            Ok(path) => path.exists() && path.is_dir(),
+            Err(_) => false,
+        }
+    } else {
+        false
+    }
+}

--- a/src/game/screens/analytics_screen.rs
+++ b/src/game/screens/analytics_screen.rs
@@ -573,7 +573,7 @@ impl AnalyticsScreen {
 
     fn render_controls(&mut self, f: &mut Frame, area: Rect) {
         let controls_line = Line::from(vec![
-            Span::styled("[←→/HL]", Style::default().fg(Colors::BORDER)),
+            Span::styled("[←→/HL]", Style::default().fg(Colors::NAVIGATION_KEY)),
             Span::styled(" Switch View  ", Style::default().fg(Colors::TEXT)),
             Span::styled("[R]", Style::default().fg(Colors::SCORE)),
             Span::styled(" Refresh  ", Style::default().fg(Colors::TEXT)),

--- a/src/game/screens/history_screen.rs
+++ b/src/game/screens/history_screen.rs
@@ -268,7 +268,10 @@ impl HistoryScreen {
 
         // Controls at the bottom row - matching title screen colors
         let controls_line = Line::from(vec![
-            Span::styled("[↑↓/JK] Navigate  ", Style::default().fg(Colors::TEXT)),
+            Span::styled(
+                "[↑↓/JK] Navigate  ",
+                Style::default().fg(Colors::NAVIGATION_KEY),
+            ),
             Span::styled("[SPACE]", Style::default().fg(Colors::SUCCESS)),
             Span::styled(" Details  ", Style::default().fg(Colors::TEXT)),
             Span::styled("[F]", Style::default().fg(Colors::BORDER)),

--- a/src/game/views/title/static_elements_view.rs
+++ b/src/game/views/title/static_elements_view.rs
@@ -58,7 +58,7 @@ impl StaticElementsView {
         execute!(stdout, MoveTo(change_col, instructions_start_row))?;
         execute!(
             stdout,
-            SetForegroundColor(Colors::to_crossterm(Colors::BORDER))
+            SetForegroundColor(Colors::to_crossterm(Colors::NAVIGATION_KEY))
         )?;
         execute!(stdout, Print("[←→/HL]"))?;
         execute!(

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -19,6 +19,7 @@ impl Colors {
     // Specific UI element colors
     pub const BACK_KEY: Color = Color::Red;
     pub const ACTION_KEY: Color = Color::LightBlue;
+    pub const NAVIGATION_KEY: Color = Color::LightBlue;
     pub const HIGHLIGHT: Color = Color::Cyan;
 
     // Metrics and performance colors (from session_detail_screen.rs)


### PR DESCRIPTION
## Summary
- Add `repo list` command with pretty ratatui-based display and aligned columns
- Add `repo play` command for interactive repository selection with navigation
- Add `repo clear` command for cache management with confirmation prompts
- Implement multi-host Git URL support (GitHub, GitLab, Bitbucket, etc.)
- Create `cli/views` module for better separation of concerns
- Remove language brackets and use muted colors for URLs for cleaner appearance
- Support SSH, HTTPS, and various Git URL formats

## Test plan
- [x] cargo check passes
- [x] cargo test passes (all 572 tests pass)
- [x] cargo clippy passes with no warnings
- [x] cargo fmt applied
- [x] Manual testing of `repo list` command displays correctly
- [x] Manual testing of `repo play` command navigation works
- [x] Multi-host URL parsing tested with various formats

🤖 Generated with [Claude Code](https://claude.ai/code)