### PR TITLE
fix: correct stage number display in StageSummary

### DIFF
--- a/src/game/screens/stage_summary_screen.rs
+++ b/src/game/screens/stage_summary_screen.rs
@@ -76,15 +76,25 @@ impl Screen for StageSummaryScreen {
         _total_result: Option<&crate::scoring::TotalResult>,
     ) -> Result<()> {
         if let Some(ref stage_result) = self.stage_result {
-            let (current_stage, total_stages) =
+            let (session_current_stage, total_stages) =
                 SessionManager::get_global_stage_info().unwrap_or((1, 3));
             let is_completed = SessionManager::is_global_session_completed().unwrap_or(true);
+
+            // Calculate the stage number that was just completed
+            let completed_stage = if is_completed {
+                // If session is completed, show the total number of stages completed
+                session_current_stage
+            } else {
+                // If session is in progress, the current stage has been incremented
+                // so we need to show the previous stage number
+                session_current_stage.saturating_sub(1).max(1)
+            };
 
             let has_next = !is_completed;
 
             StageCompletionView::render_complete(
                 stage_result,
-                current_stage,
+                completed_stage,
                 total_stages,
                 has_next,
                 stage_result.keystrokes,

--- a/src/game/session_manager.rs
+++ b/src/game/session_manager.rs
@@ -460,8 +460,13 @@ impl SessionManager {
         match self.state {
             SessionState::InProgress { current_stage, .. } => current_stage,
             SessionState::Completed { .. } => {
-                // For completed sessions, return the number of stages actually completed
-                self.stage_results.len().max(1)
+                // For completed sessions, return the number of successfully completed stages
+                let completed = self
+                    .stage_results
+                    .iter()
+                    .filter(|sr| !sr.was_skipped && !sr.was_failed)
+                    .count();
+                completed.max(1).min(self.config.max_stages)
             }
             _ => 0,
         }

--- a/src/game/session_manager.rs
+++ b/src/game/session_manager.rs
@@ -459,6 +459,10 @@ impl SessionManager {
     fn current_stage(&self) -> usize {
         match self.state {
             SessionState::InProgress { current_stage, .. } => current_stage,
+            SessionState::Completed { .. } => {
+                // For completed sessions, return the number of stages actually completed
+                self.stage_results.len().max(1)
+            }
             _ => 0,
         }
     }


### PR DESCRIPTION
## Summary
- Fix stage number display issue in StageSummary screen
- Previously first stage showed as 2 and last stage showed as 0
- Now correctly displays stages 1, 2, 3 in order

## Changes
- Modified `SessionManager::current_stage()` to return correct stage count for completed sessions
- Updated `stage_summary_screen.rs` to calculate completed stage number properly
- Added logic to distinguish between in-progress and completed session states

## Test plan
- [x] Build project successfully
- [x] Run all tests and verify they pass
- [ ] Manual testing to verify stage numbers display correctly (1, 2, 3)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stage numbering on the Stage Summary screen to reflect completed stages accurately.
  * Completed sessions now display the final completed stage instead of showing zero.
  * In-progress sessions show the correct current stage; completed sessions show final completed count.
  * Stage numbers are clamped to valid ranges to avoid invalid values.
  * Maintains correct “has next” behavior for consistent navigation and progress display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->