### PR TITLE
fix: correct comment range detection in middle chunk extraction

### DIFF
--- a/src/extractor/core/extractor.rs
+++ b/src/extractor/core/extractor.rs
@@ -122,9 +122,13 @@ impl CommonExtractor {
                 large_chunk.content.as_bytes(),
             );
 
-            let chunk_comment_ranges =
-                Self::extract_comment_ranges(&chunk_tree, &large_chunk.content, language, &[])?;
             let chunk_byte_to_char_cache = Self::build_byte_to_char_cache(&large_chunk.content);
+            let chunk_comment_ranges = Self::extract_comment_ranges(
+                &chunk_tree,
+                &large_chunk.content,
+                language,
+                &chunk_byte_to_char_cache,
+            )?;
 
             while let Some(match_) = chunk_matches.next() {
                 for capture in match_.captures {

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_c_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_c_complex_algorithm_extraction.snap
@@ -170,7 +170,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          435,
+          475
+        ],
+        [
+          547,
+          555
+        ],
+        [
+          727,
+          750
+        ]
+      ],
       "content": "    for (size_t i = 0; i < input_size; i++) {\n        int value = input[i];\n        ProcessedItem item;\n        item.id = (int)i;\n\n        if (value > threshold) {\n            int transformed = value * 2;\n            item.value = transformed;\n\n            if (transformed > threshold * 3) {\n                strcpy(item.category, \"HIGH\");\n            } else {\n                strcpy(item.category, \"MEDIUM\");\n            }\n\n            // Additional processing for high values\n            if (transformed > 100) {\n                item.value += 10; // bonus\n            }\n        } else if (value > 0) {\n            item.value = value + threshold;\n            strcpy(item.category, \"LOW\");\n        } else {\n            continue; // skip negative values\n        }\n\n        results[result_count++] = item;\n    }",
       "end_line": 54,
       "language": "c",
@@ -190,7 +203,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          304,
+          344
+        ],
+        [
+          416,
+          424
+        ]
+      ],
       "content": "        if (value > threshold) {\n            int transformed = value * 2;\n            item.value = transformed;\n\n            if (transformed > threshold * 3) {\n                strcpy(item.category, \"HIGH\");\n            } else {\n                strcpy(item.category, \"MEDIUM\");\n            }\n\n            // Additional processing for high values\n            if (transformed > 100) {\n                item.value += 10; // bonus\n            }\n        }",
       "end_line": 46,
       "language": "c",
@@ -200,7 +222,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          304,
+          344
+        ],
+        [
+          416,
+          424
+        ],
+        [
+          596,
+          619
+        ]
+      ],
       "content": "        if (value > threshold) {\n            int transformed = value * 2;\n            item.value = transformed;\n\n            if (transformed > threshold * 3) {\n                strcpy(item.category, \"HIGH\");\n            } else {\n                strcpy(item.category, \"MEDIUM\");\n            }\n\n            // Additional processing for high values\n            if (transformed > 100) {\n                item.value += 10; // bonus\n            }\n        } else if (value > 0) {\n            item.value = value + threshold;\n            strcpy(item.category, \"LOW\");\n        } else {\n            continue; // skip negative values\n        }",
       "end_line": 51,
       "language": "c",
@@ -250,7 +285,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          71,
+          79
+        ]
+      ],
       "content": "            if (transformed > 100) {\n                item.value += 10; // bonus\n            }",
       "end_line": 45,
       "language": "c",
@@ -270,7 +310,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          157,
+          180
+        ]
+      ],
       "content": "        } else if (value > 0) {\n            item.value = value + threshold;\n            strcpy(item.category, \"LOW\");\n        } else {\n            continue; // skip negative values\n        }",
       "end_line": 51,
       "language": "c",
@@ -280,7 +325,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          39,
+          62
+        ]
+      ],
       "content": "        } else {\n            continue; // skip negative values\n        }",
       "end_line": 51,
       "language": "c",
@@ -290,7 +340,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          36,
+          71
+        ],
+        [
+          254,
+          302
+        ]
+      ],
       "content": "    if (result_count > 0) {\n        // Calculate average for validation\n        int total = 0;\n        for (size_t i = 0; i < result_count; i++) {\n            total += results[i].value;\n        }\n        int average = total / (int)result_count;\n\n        // Add average as metadata (simplified approach)\n        printf(\"Average processed value: %d\\n\", average);\n    }",
       "end_line": 67,
       "language": "c",
@@ -387,7 +446,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          541,
+          574
+        ]
+      ],
       "content": "    for (size_t i = 0; i < count; i++) {\n        ProcessedItem *item = &items[i];\n        int category_index = -1;\n\n        if (strcmp(item->category, \"LOW\") == 0) {\n            category_index = 0;\n        } else if (strcmp(item->category, \"MEDIUM\") == 0) {\n            category_index = 1;\n        } else if (strcmp(item->category, \"HIGH\") == 0) {\n            category_index = 2;\n        }\n\n        if (category_index >= 0) {\n            category_counts[category_index]++;\n            value_sums[category_index] += item->value;\n\n            // Time-based analysis simulation\n            if (item->value > 1000) {\n                printf(\"High value item found: %d\\n\", item->value);\n            }\n        }\n    }",
       "end_line": 102,
       "language": "c",
@@ -457,7 +521,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          150,
+          183
+        ]
+      ],
       "content": "        if (category_index >= 0) {\n            category_counts[category_index]++;\n            value_sums[category_index] += item->value;\n\n            // Time-based analysis simulation\n            if (item->value > 1000) {\n                printf(\"High value item found: %d\\n\", item->value);\n            }\n        }",
       "end_line": 101,
       "language": "c",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_cpp_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_cpp_complex_algorithm_extraction.snap
@@ -252,7 +252,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          542,
+          582
+        ],
+        [
+          713,
+          721
+        ],
+        [
+          908,
+          931
+        ]
+      ],
       "content": "        for (size_t i = 0; i < input.size(); ++i) {\n            const T& value = input[i];\n            std::string cache_key = \"item_\" + std::to_string(i);\n\n            auto cache_it = cache.find(cache_key);\n            if (cache_it != cache.end()) {\n                results.push_back(cache_it->second);\n                continue;\n            }\n\n            T processed_value;\n            if (value > static_cast<T>(threshold)) {\n                processed_value = value * static_cast<T>(2);\n                processed_count++;\n\n                // Additional processing for high values\n                if (processed_value > static_cast<T>(threshold * 3)) {\n                    processed_value += static_cast<T>(10); // bonus\n                }\n            } else if (value > static_cast<T>(0)) {\n                processed_value = value + static_cast<T>(threshold);\n            } else {\n                continue; // skip negative values\n            }\n\n            cache[cache_key] = processed_value;\n            processing_log.push_back(processed_value);\n            results.push_back(processed_value);\n        }",
       "end_line": 52,
       "language": "cpp",
@@ -292,7 +305,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          166,
+          206
+        ],
+        [
+          337,
+          345
+        ]
+      ],
       "content": "            if (value > static_cast<T>(threshold)) {\n                processed_value = value * static_cast<T>(2);\n                processed_count++;\n\n                // Additional processing for high values\n                if (processed_value > static_cast<T>(threshold * 3)) {\n                    processed_value += static_cast<T>(10); // bonus\n                }\n            }",
       "end_line": 43,
       "language": "cpp",
@@ -302,7 +324,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          166,
+          206
+        ],
+        [
+          337,
+          345
+        ],
+        [
+          532,
+          555
+        ]
+      ],
       "content": "            if (value > static_cast<T>(threshold)) {\n                processed_value = value * static_cast<T>(2);\n                processed_count++;\n\n                // Additional processing for high values\n                if (processed_value > static_cast<T>(threshold * 3)) {\n                    processed_value += static_cast<T>(10); // bonus\n                }\n            } else if (value > static_cast<T>(0)) {\n                processed_value = value + static_cast<T>(threshold);\n            } else {\n                continue; // skip negative values\n            }",
       "end_line": 47,
       "language": "cpp",
@@ -312,7 +347,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          130,
+          138
+        ]
+      ],
       "content": "                if (processed_value > static_cast<T>(threshold * 3)) {\n                    processed_value += static_cast<T>(10); // bonus\n                }",
       "end_line": 42,
       "language": "cpp",
@@ -332,7 +372,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          168,
+          191
+        ]
+      ],
       "content": "            } else if (value > static_cast<T>(0)) {\n                processed_value = value + static_cast<T>(threshold);\n            } else {\n                continue; // skip negative values\n            }",
       "end_line": 47,
       "language": "cpp",
@@ -342,7 +387,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          47,
+          70
+        ]
+      ],
       "content": "            } else {\n                continue; // skip negative values\n            }",
       "end_line": 47,
       "language": "cpp",
@@ -352,7 +402,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          202,
+          236
+        ]
+      ],
       "content": "        if (processed_count > 0) {\n            T total = std::accumulate(results.begin(), results.end(), static_cast<T>(0));\n            T average = total / static_cast<T>(results.size());\n\n            // Add average to log for analysis\n            processing_log.push_back(average);\n        }",
       "end_line": 61,
       "language": "cpp",
@@ -415,7 +470,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          395,
+          426
+        ]
+      ],
       "content": "        for (const auto& item : data) {\n            std::string category;\n\n            if (item > static_cast<T>(threshold * 2)) {\n                category = \"HIGH\";\n            } else if (item > static_cast<T>(threshold)) {\n                category = \"MEDIUM\";\n            } else {\n                category = \"LOW\";\n            }\n\n            categories[category].push_back(item);\n\n            // Additional pattern detection\n            if (item > static_cast<T>(1000)) {\n                categories[\"PREMIUM\"].push_back(item);\n            }\n        }",
       "end_line": 88,
       "language": "cpp",
@@ -589,7 +649,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          96,
+          134
+        ],
+        [
+          259,
+          300
+        ],
+        [
+          599,
+          633
+        ]
+      ],
       "content": "        for (const auto& text : input) {\n            std::string processed = text;\n\n            // Pattern matching and transformation\n            size_t pos = 0;\n            while ((pos = processed.find(pattern, pos)) != std::string::npos) {\n                // Replace pattern with uppercase version\n                std::string replacement = pattern;\n                std::transform(replacement.begin(), replacement.end(), replacement.begin(), ::toupper);\n                processed.replace(pos, pattern.length(), replacement);\n                pos += replacement.length();\n            }\n\n            // Additional text transformations\n            if (processed.length() > 50) {\n                processed = processed.substr(0, 47) + \"...\";\n            }\n\n            if (!processed.empty()) {\n                results.push_back(processed);\n            }\n        }",
       "end_line": 133,
       "language": "cpp",
@@ -619,7 +692,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          96,
+          137
+        ]
+      ],
       "content": "            while ((pos = processed.find(pattern, pos)) != std::string::npos) {\n                // Replace pattern with uppercase version\n                std::string replacement = pattern;\n                std::transform(replacement.begin(), replacement.end(), replacement.begin(), ::toupper);\n                processed.replace(pos, pattern.length(), replacement);\n                pos += replacement.length();\n            }",
       "end_line": 123,
       "language": "cpp",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_csharp_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_csharp_complex_algorithm_extraction.snap
@@ -306,7 +306,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          974,
+          1014
+        ],
+        [
+          1592,
+          1614
+        ]
+      ],
       "content": "            for (int i = 0; i < input.Count; i++)\n            {\n                var value = input[i];\n                var cacheKey = $\"item_{i}_{value}\";\n\n                if (_cache.TryGetValue(cacheKey, out var cachedItem))\n                {\n                    results.Add(cachedItem);\n                    continue;\n                }\n\n                var processedItem = new ProcessedItem\n                {\n                    Id = i,\n                    OriginalValue = Convert.ToInt32(value),\n                    Timestamp = DateTime.Now,\n                    Metadata = new Dictionary<string, object>()\n                };\n\n                if (value.CompareTo(_threshold) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue * 2;\n                    processedItem.Category = processedItem.TransformedValue > Convert.ToInt32(_threshold) * 3 ? \"HIGH\" : \"MEDIUM\";\n                    processedCount++;\n\n                    // Additional processing for high values\n                    if (processedItem.TransformedValue > 100)\n                    {\n                        processedItem.Metadata[\"bonus\"] = true;\n                        processedItem.TransformedValue += 10;\n                    }\n                }\n                else if (value.CompareTo(default(T)) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue + Convert.ToInt32(_threshold);\n                    processedItem.Category = \"LOW\";\n                }\n                else\n                {\n                    continue; // skip invalid values\n                }\n\n                _cache[cacheKey] = processedItem;\n                _processingLog.Add(processedItem);\n                results.Add(processedItem);\n            }",
       "end_line": 82,
       "language": "csharp",
@@ -316,7 +325,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          924,
+          964
+        ],
+        [
+          1542,
+          1564
+        ]
+      ],
       "content": "            {\n                var value = input[i];\n                var cacheKey = $\"item_{i}_{value}\";\n\n                if (_cache.TryGetValue(cacheKey, out var cachedItem))\n                {\n                    results.Add(cachedItem);\n                    continue;\n                }\n\n                var processedItem = new ProcessedItem\n                {\n                    Id = i,\n                    OriginalValue = Convert.ToInt32(value),\n                    Timestamp = DateTime.Now,\n                    Metadata = new Dictionary<string, object>()\n                };\n\n                if (value.CompareTo(_threshold) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue * 2;\n                    processedItem.Category = processedItem.TransformedValue > Convert.ToInt32(_threshold) * 3 ? \"HIGH\" : \"MEDIUM\";\n                    processedCount++;\n\n                    // Additional processing for high values\n                    if (processedItem.TransformedValue > 100)\n                    {\n                        processedItem.Metadata[\"bonus\"] = true;\n                        processedItem.TransformedValue += 10;\n                    }\n                }\n                else if (value.CompareTo(default(T)) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue + Convert.ToInt32(_threshold);\n                    processedItem.Category = \"LOW\";\n                }\n                else\n                {\n                    continue; // skip invalid values\n                }\n\n                _cache[cacheKey] = processedItem;\n                _processingLog.Add(processedItem);\n                results.Add(processedItem);\n            }",
       "end_line": 82,
       "language": "csharp",
@@ -346,7 +364,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          347,
+          387
+        ],
+        [
+          965,
+          987
+        ]
+      ],
       "content": "                if (value.CompareTo(_threshold) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue * 2;\n                    processedItem.Category = processedItem.TransformedValue > Convert.ToInt32(_threshold) * 3 ? \"HIGH\" : \"MEDIUM\";\n                    processedCount++;\n\n                    // Additional processing for high values\n                    if (processedItem.TransformedValue > 100)\n                    {\n                        processedItem.Metadata[\"bonus\"] = true;\n                        processedItem.TransformedValue += 10;\n                    }\n                }\n                else if (value.CompareTo(default(T)) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue + Convert.ToInt32(_threshold);\n                    processedItem.Category = \"LOW\";\n                }\n                else\n                {\n                    continue; // skip invalid values\n                }",
       "end_line": 77,
       "language": "csharp",
@@ -356,7 +383,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          294,
+          334
+        ]
+      ],
       "content": "                {\n                    processedItem.TransformedValue = processedItem.OriginalValue * 2;\n                    processedItem.Category = processedItem.TransformedValue > Convert.ToInt32(_threshold) * 3 ? \"HIGH\" : \"MEDIUM\";\n                    processedCount++;\n\n                    // Additional processing for high values\n                    if (processedItem.TransformedValue > 100)\n                    {\n                        processedItem.Metadata[\"bonus\"] = true;\n                        processedItem.TransformedValue += 10;\n                    }\n                }",
       "end_line": 68,
       "language": "csharp",
@@ -386,7 +418,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          327,
+          349
+        ]
+      ],
       "content": "                else if (value.CompareTo(default(T)) > 0)\n                {\n                    processedItem.TransformedValue = processedItem.OriginalValue + Convert.ToInt32(_threshold);\n                    processedItem.Category = \"LOW\";\n                }\n                else\n                {\n                    continue; // skip invalid values\n                }",
       "end_line": 77,
       "language": "csharp",
@@ -406,7 +443,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          48,
+          70
+        ]
+      ],
       "content": "                {\n                    continue; // skip invalid values\n                }",
       "end_line": 77,
       "language": "csharp",
@@ -416,7 +458,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          221,
+          244
+        ]
+      ],
       "content": "            if (processedCount > 0)\n            {\n                var average = results.Average(r => r.TransformedValue);\n                Console.WriteLine($\"Processing complete. Average: {average:F2}\");\n\n                // Add summary metadata\n                foreach (var item in results)\n                {\n                    item.Metadata[\"processing_average\"] = average;\n                }\n            }",
       "end_line": 95,
       "language": "csharp",
@@ -426,7 +473,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          185,
+          208
+        ]
+      ],
       "content": "            {\n                var average = results.Average(r => r.TransformedValue);\n                Console.WriteLine($\"Processing complete. Average: {average:F2}\");\n\n                // Add summary metadata\n                foreach (var item in results)\n                {\n                    item.Metadata[\"processing_average\"] = average;\n                }\n            }",
       "end_line": 95,
       "language": "csharp",
@@ -489,7 +541,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          191,
+          243
+        ],
+        [
+          930,
+          952
+        ],
+        [
+          1334,
+          1356
+        ]
+      ],
       "content": "        {\n            var analysis = new Dictionary<string, object>();\n            var categoryGroups = items.GroupBy(i => i.Category).ToDictionary(g => g.Key, g => g.ToList());\n\n            // Pattern analysis logic - extractable middle chunk\n            foreach (var categoryGroup in categoryGroups)\n            {\n                var category = categoryGroup.Key;\n                var categoryItems = categoryGroup.Value;\n\n                var categoryAnalysis = new Dictionary<string, object>\n                {\n                    [\"count\"] = categoryItems.Count,\n                    [\"percentage\"] = (double)categoryItems.Count / items.Count * 100,\n                    [\"avg_value\"] = categoryItems.Average(i => i.TransformedValue),\n                    [\"min_value\"] = categoryItems.Min(i => i.TransformedValue),\n                    [\"max_value\"] = categoryItems.Max(i => i.TransformedValue)\n                };\n\n                // Time-based analysis\n                var recentItems = categoryItems.Where(i => (DateTime.Now - i.Timestamp).TotalMinutes < 1).ToList();\n                if (recentItems.Any())\n                {\n                    categoryAnalysis[\"recent_count\"] = recentItems.Count;\n                    categoryAnalysis[\"recent_avg\"] = recentItems.Average(i => i.TransformedValue);\n                }\n\n                // High-value analysis\n                var highValueItems = categoryItems.Where(i => i.TransformedValue > 1000).ToList();\n                if (highValueItems.Any())\n                {\n                    categoryAnalysis[\"high_value_count\"] = highValueItems.Count;\n                }\n\n                analysis[category] = categoryAnalysis;\n            }\n\n            analysis[\"total_items\"] = items.Count;\n            analysis[\"processing_time\"] = DateTime.Now;\n\n            return analysis;\n        }",
       "end_line": 142,
       "language": "csharp",
@@ -499,7 +564,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          686,
+          708
+        ],
+        [
+          1090,
+          1112
+        ]
+      ],
       "content": "            foreach (var categoryGroup in categoryGroups)\n            {\n                var category = categoryGroup.Key;\n                var categoryItems = categoryGroup.Value;\n\n                var categoryAnalysis = new Dictionary<string, object>\n                {\n                    [\"count\"] = categoryItems.Count,\n                    [\"percentage\"] = (double)categoryItems.Count / items.Count * 100,\n                    [\"avg_value\"] = categoryItems.Average(i => i.TransformedValue),\n                    [\"min_value\"] = categoryItems.Min(i => i.TransformedValue),\n                    [\"max_value\"] = categoryItems.Max(i => i.TransformedValue)\n                };\n\n                // Time-based analysis\n                var recentItems = categoryItems.Where(i => (DateTime.Now - i.Timestamp).TotalMinutes < 1).ToList();\n                if (recentItems.Any())\n                {\n                    categoryAnalysis[\"recent_count\"] = recentItems.Count;\n                    categoryAnalysis[\"recent_avg\"] = recentItems.Average(i => i.TransformedValue);\n                }\n\n                // High-value analysis\n                var highValueItems = categoryItems.Where(i => i.TransformedValue > 1000).ToList();\n                if (highValueItems.Any())\n                {\n                    categoryAnalysis[\"high_value_count\"] = highValueItems.Count;\n                }\n\n                analysis[category] = categoryAnalysis;\n            }",
       "end_line": 136,
       "language": "csharp",
@@ -509,7 +583,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          628,
+          650
+        ],
+        [
+          1032,
+          1054
+        ]
+      ],
       "content": "            {\n                var category = categoryGroup.Key;\n                var categoryItems = categoryGroup.Value;\n\n                var categoryAnalysis = new Dictionary<string, object>\n                {\n                    [\"count\"] = categoryItems.Count,\n                    [\"percentage\"] = (double)categoryItems.Count / items.Count * 100,\n                    [\"avg_value\"] = categoryItems.Average(i => i.TransformedValue),\n                    [\"min_value\"] = categoryItems.Min(i => i.TransformedValue),\n                    [\"max_value\"] = categoryItems.Max(i => i.TransformedValue)\n                };\n\n                // Time-based analysis\n                var recentItems = categoryItems.Where(i => (DateTime.Now - i.Timestamp).TotalMinutes < 1).ToList();\n                if (recentItems.Any())\n                {\n                    categoryAnalysis[\"recent_count\"] = recentItems.Count;\n                    categoryAnalysis[\"recent_avg\"] = recentItems.Average(i => i.TransformedValue);\n                }\n\n                // High-value analysis\n                var highValueItems = categoryItems.Where(i => i.TransformedValue > 1000).ToList();\n                if (highValueItems.Any())\n                {\n                    categoryAnalysis[\"high_value_count\"] = highValueItems.Count;\n                }\n\n                analysis[category] = categoryAnalysis;\n            }",
       "end_line": 136,
       "language": "csharp",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_dart_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_dart_complex_algorithm_extraction.snap
@@ -178,7 +178,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          844,
+          884
+        ],
+        [
+          1708,
+          1731
+        ],
+        [
+          1863,
+          1885
+        ]
+      ],
       "content": "    for (var i = 0; i < input.length; i++) {\n      final value = input[i];\n      final cacheKey = 'item_${i}_$value';\n\n      if (_cache.containsKey(cacheKey)) {\n        final cachedItem = _cache[cacheKey]!;\n        results.add(cachedItem);\n        continue;\n      }\n\n      late ProcessedItem processedItem;\n      if (value > _threshold) {\n        final transformedValue = value * 2;\n        final category = transformedValue > _threshold * 3 ? 'HIGH' : 'MEDIUM';\n\n        processedItem = ProcessedItem(\n          id: i,\n          originalValue: value,\n          transformedValue: transformedValue,\n          category: category,\n          timestamp: DateTime.now(),\n          metadata: {\n            'processed': true,\n            'multiplier': 0,\n            'processor': 'enhanced',\n          },\n        );\n\n        processedCount++;\n\n        // Additional processing for high values\n        if (transformedValue > 100) {\n          processedItem = ProcessedItem(\n            id: processedItem.id,\n            originalValue: processedItem.originalValue,\n            transformedValue: processedItem.transformedValue + 10,\n            category: processedItem.category,\n            timestamp: processedItem.timestamp,\n            metadata: {...processedItem.metadata, 'bonus': true},\n          );\n        }\n      } else if (value > 0) {\n        processedItem = ProcessedItem(\n          id: i,\n          originalValue: value,\n          transformedValue: value + _threshold,\n          category: 'LOW',\n          timestamp: DateTime.now(),\n          metadata: {\n            'processed': true,\n            'adjusted': true,\n            'processor': 'basic',\n          },\n        );\n      } else {\n        continue; // skip negative values\n      }\n\n      _cache[cacheKey] = processedItem;\n      _processingLog.add(processedItem);\n      results.add(processedItem);\n\n      // Simulate async work\n      if (i % 10 == 0) {\n        await Future.delayed(Duration(milliseconds: 1));\n      }\n    }",
       "end_line": 101,
       "language": "dart",
@@ -238,7 +251,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          537,
+          577
+        ]
+      ],
       "content": "      if (value > _threshold) {\n        final transformedValue = value * 2;\n        final category = transformedValue > _threshold * 3 ? 'HIGH' : 'MEDIUM';\n\n        processedItem = ProcessedItem(\n          id: i,\n          originalValue: value,\n          transformedValue: transformedValue,\n          category: category,\n          timestamp: DateTime.now(),\n          metadata: {\n            'processed': true,\n            'multiplier': 0,\n            'processor': 'enhanced',\n          },\n        );\n\n        processedCount++;\n\n        // Additional processing for high values\n        if (transformedValue > 100) {\n          processedItem = ProcessedItem(\n            id: processedItem.id,\n            originalValue: processedItem.originalValue,\n            transformedValue: processedItem.transformedValue + 10,\n            category: processedItem.category,\n            timestamp: processedItem.timestamp,\n            metadata: {...processedItem.metadata, 'bonus': true},\n          );\n        }\n      }",
       "end_line": 76,
       "language": "dart",
@@ -248,7 +266,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          537,
+          577
+        ],
+        [
+          1401,
+          1424
+        ]
+      ],
       "content": "      if (value > _threshold) {\n        final transformedValue = value * 2;\n        final category = transformedValue > _threshold * 3 ? 'HIGH' : 'MEDIUM';\n\n        processedItem = ProcessedItem(\n          id: i,\n          originalValue: value,\n          transformedValue: transformedValue,\n          category: category,\n          timestamp: DateTime.now(),\n          metadata: {\n            'processed': true,\n            'multiplier': 0,\n            'processor': 'enhanced',\n          },\n        );\n\n        processedCount++;\n\n        // Additional processing for high values\n        if (transformedValue > 100) {\n          processedItem = ProcessedItem(\n            id: processedItem.id,\n            originalValue: processedItem.originalValue,\n            transformedValue: processedItem.transformedValue + 10,\n            category: processedItem.category,\n            timestamp: processedItem.timestamp,\n            metadata: {...processedItem.metadata, 'bonus': true},\n          );\n        }\n      } else if (value > 0) {\n        processedItem = ProcessedItem(\n          id: i,\n          originalValue: value,\n          transformedValue: value + _threshold,\n          category: 'LOW',\n          timestamp: DateTime.now(),\n          metadata: {\n            'processed': true,\n            'adjusted': true,\n            'processor': 'basic',\n          },\n        );\n      } else {\n        continue; // skip negative values\n      }",
       "end_line": 91,
       "language": "dart",
@@ -298,7 +325,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          404,
+          427
+        ]
+      ],
       "content": "      } else if (value > 0) {\n        processedItem = ProcessedItem(\n          id: i,\n          originalValue: value,\n          transformedValue: value + _threshold,\n          category: 'LOW',\n          timestamp: DateTime.now(),\n          metadata: {\n            'processed': true,\n            'adjusted': true,\n            'processor': 'basic',\n          },\n        );\n      } else {\n        continue; // skip negative values\n      }",
       "end_line": 91,
       "language": "dart",
@@ -308,7 +340,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          33,
+          56
+        ]
+      ],
       "content": "      } else {\n        continue; // skip negative values\n      }",
       "end_line": 91,
       "language": "dart",
@@ -328,7 +365,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          216,
+          244
+        ]
+      ],
       "content": "    if (processedCount > 0) {\n      final average = results.map((r) => r.transformedValue).reduce((a, b) => a + b) / results.length;\n      print('Processing complete. Average: ${average.toStringAsFixed(2)}');\n\n      // Add processing statistics\n      for (final item in results) {\n        item.metadata['processing_average'] = average;\n      }\n    }",
       "end_line": 112,
       "language": "dart",
@@ -368,7 +410,24 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          175,
+          201
+        ],
+        [
+          314,
+          366
+        ],
+        [
+          866,
+          888
+        ],
+        [
+          1333,
+          1355
+        ]
+      ],
       "content": "  Map<String, dynamic> analyzePatterns(List<ProcessedItem> items) {\n    final analysis = <String, dynamic>{};\n    final categoryGroups = <String, List<ProcessedItem>>{};\n\n    // Group items by category\n    for (final item in items) {\n      categoryGroups.putIfAbsent(item.category, () => []).add(item);\n    }\n\n    // Pattern analysis logic - extractable middle chunk\n    for (final entry in categoryGroups.entries) {\n      final category = entry.key;\n      final categoryItems = entry.value;\n\n      final values = categoryItems.map((i) => i.transformedValue);\n      final categoryAnalysis = {\n        'count': categoryItems.length,\n        'percentage': (categoryItems.length / items.length) * 100,\n        'avg_value': values.reduce((a, b) => a + b) / values.length,\n        'min_value': values.reduce(min),\n        'max_value': values.reduce(max),\n      };\n\n      // Time-based analysis\n      final now = DateTime.now();\n      final recentItems = categoryItems.where((i) =>\n        now.difference(i.timestamp).inMinutes < 1\n      ).toList();\n\n      if (recentItems.isNotEmpty) {\n        final recentValues = recentItems.map((i) => i.transformedValue);\n        categoryAnalysis['recent_count'] = recentItems.length;\n        categoryAnalysis['recent_avg'] = recentValues.reduce((a, b) => a + b) / recentValues.length;\n      }\n\n      // High-value analysis\n      final highValueItems = categoryItems.where((i) => i.transformedValue > 1000);\n      if (highValueItems.isNotEmpty) {\n        categoryAnalysis['high_value_count'] = highValueItems.length;\n      }\n\n      analysis[category] = categoryAnalysis;\n    }\n\n    analysis['total_items'] = items.length;\n    analysis['processing_time'] = DateTime.now().toIso8601String();\n\n    return analysis;\n  }",
       "end_line": 165,
       "language": "dart",
@@ -408,7 +467,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          499,
+          521
+        ],
+        [
+          966,
+          988
+        ]
+      ],
       "content": "    for (final entry in categoryGroups.entries) {\n      final category = entry.key;\n      final categoryItems = entry.value;\n\n      final values = categoryItems.map((i) => i.transformedValue);\n      final categoryAnalysis = {\n        'count': categoryItems.length,\n        'percentage': (categoryItems.length / items.length) * 100,\n        'avg_value': values.reduce((a, b) => a + b) / values.length,\n        'min_value': values.reduce(min),\n        'max_value': values.reduce(max),\n      };\n\n      // Time-based analysis\n      final now = DateTime.now();\n      final recentItems = categoryItems.where((i) =>\n        now.difference(i.timestamp).inMinutes < 1\n      ).toList();\n\n      if (recentItems.isNotEmpty) {\n        final recentValues = recentItems.map((i) => i.transformedValue);\n        categoryAnalysis['recent_count'] = recentItems.length;\n        categoryAnalysis['recent_avg'] = recentValues.reduce((a, b) => a + b) / recentValues.length;\n      }\n\n      // High-value analysis\n      final highValueItems = categoryItems.where((i) => i.transformedValue > 1000);\n      if (highValueItems.isNotEmpty) {\n        categoryAnalysis['high_value_count'] = highValueItems.length;\n      }\n\n      analysis[category] = categoryAnalysis;\n    }",
       "end_line": 159,
       "language": "dart",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_go_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_go_complex_algorithm_extraction.snap
@@ -295,7 +295,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          162,
+          184
+        ],
+        [
+          547,
+          577
+        ]
+      ],
       "content": "    for _, item := range items {\n        category := item.Category\n        categoryCount[category]++\n        valueSum[category] += item.TransformedValue\n\n        // Time-based analysis\n        timeDiff := time.Since(item.Timestamp)\n        if timeDiff < time.Minute {\n            recentKey := fmt.Sprintf(\"%s_recent\", category)\n            if count, exists := categoryCount[recentKey]; exists {\n                categoryCount[recentKey] = count + 1\n            } else {\n                categoryCount[recentKey] = 1\n            }\n        }\n\n        // Value distribution analysis\n        if item.TransformedValue > 1000 {\n            highValueKey := fmt.Sprintf(\"%s_high_value\", category)\n            categoryCount[highValueKey]++\n        }\n    }",
       "end_line": 140,
       "language": "go",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_haskell_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_haskell_complex_algorithm_extraction.snap
@@ -143,7 +143,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Variable",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          242,
+          297
+        ]
+      ],
       "content": "        let cacheKey = \"item_\" ++ show (length acc) ++ \"_\" ++ show value\n        in case Map.lookup cacheKey cache of\n            Just cachedItem -> processWithCache rest thresh cache (cachedItem : acc)\n            Nothing ->\n                -- Main processing algorithm - extractable middle chunk\n                let processedItem = if value > thresh\n                        then let transformed = value * 2\n                                 cat = if transformed > thresh * 3 then \"HIGH\" else \"MEDIUM\"\n                                 bonusValue = if transformed > 100 then transformed + 10 else transformed\n                             in ProcessedItem (length acc) value bonusValue cat \"now\"\n                        else if value > 0\n                        then ProcessedItem (length acc) value (value + thresh) \"LOW\" \"now\"\n                        else ProcessedItem (length acc) value 0 \"INVALID\" \"now\"\n\n                    newCache = Map.insert cacheKey processedItem cache\n                in if category processedItem == \"INVALID\"\n                   then processWithCache rest thresh newCache acc\n                   else processWithCache rest thresh newCache (processedItem : acc)",
       "end_line": 38,
       "language": "haskell",
@@ -153,7 +158,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          169,
+          224
+        ]
+      ],
       "content": "        in case Map.lookup cacheKey cache of\n            Just cachedItem -> processWithCache rest thresh cache (cachedItem : acc)\n            Nothing ->\n                -- Main processing algorithm - extractable middle chunk\n                let processedItem = if value > thresh\n                        then let transformed = value * 2\n                                 cat = if transformed > thresh * 3 then \"HIGH\" else \"MEDIUM\"\n                                 bonusValue = if transformed > 100 then transformed + 10 else transformed\n                             in ProcessedItem (length acc) value bonusValue cat \"now\"\n                        else if value > 0\n                        then ProcessedItem (length acc) value (value + thresh) \"LOW\" \"now\"\n                        else ProcessedItem (length acc) value 0 \"INVALID\" \"now\"\n\n                    newCache = Map.insert cacheKey processedItem cache\n                in if category processedItem == \"INVALID\"\n                   then processWithCache rest thresh newCache acc\n                   else processWithCache rest thresh newCache (processedItem : acc)",
       "end_line": 38,
       "language": "haskell",
@@ -323,7 +333,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Variable",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          216,
+          268
+        ]
+      ],
       "content": "        let cat = category firstItem\n            values = map (fromIntegral . transformedValue) group\n            count = fromIntegral $ length group\n            totalItems = fromIntegral $ length items\n\n            -- Pattern analysis logic - extractable middle chunk\n            avgValue = sum values / count\n            minValue = minimum values\n            maxValue = maximum values\n            percentage = (count / totalItems) * 100\n\n            highValueItems = filter (> 1000) values\n            highValueCount = fromIntegral $ length highValueItems\n\n            recentItems = filter (\\item -> timestamp item == \"now\") group\n            recentCount = fromIntegral $ length recentItems\n\n            analysis = Map.fromList\n                [ (\"count\", count)\n                , (\"percentage\", percentage)\n                , (\"avg_value\", avgValue)\n                , (\"min_value\", minValue)\n                , (\"max_value\", maxValue)\n                , (\"high_value_count\", highValueCount)\n                , (\"recent_count\", recentCount)\n                ]\n        in (cat, analysis)",
       "end_line": 72,
       "language": "haskell",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_java_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_java_complex_algorithm_extraction.snap
@@ -159,7 +159,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          415,
+          446
+        ]
+      ],
       "content": "        for (int i = 0; i < items.size(); i++) {\n            DataItem item = items.get(i);\n            String cacheKey = \"item_\" + i + \"_\" + item.getId();\n\n            ProcessedItem processedItem;\n            if (cache.containsKey(cacheKey)) {\n                processedItem = (ProcessedItem) cache.get(cacheKey);\n                processingLog.add(\"Cache hit for: \" + cacheKey);\n            } else {\n                // Complex transformation logic\n                if (item.getValue() > threshold) {\n                    int transformedValue = item.getValue() * 2;\n                    String category = transformedValue > threshold * 3 ? \"HIGH\" : \"MEDIUM\";\n\n                    processedItem = new ProcessedItem(\n                        item.getId(),\n                        item.getValue(),\n                        transformedValue,\n                        category,\n                        System.currentTimeMillis()\n                    );\n\n                    processedCount++;\n                } else {\n                    int adjustedValue = item.getValue() + threshold;\n                    processedItem = new ProcessedItem(\n                        item.getId(),\n                        item.getValue(),\n                        adjustedValue,\n                        \"LOW\",\n                        System.currentTimeMillis()\n                    );\n                }\n\n                cache.put(cacheKey, processedItem);\n                processingLog.add(\"Processed new item: \" + cacheKey);\n            }\n\n            results.add(processedItem);\n        }",
       "end_line": 58,
       "language": "java",
@@ -179,7 +184,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          218,
+          249
+        ]
+      ],
       "content": "            if (cache.containsKey(cacheKey)) {\n                processedItem = (ProcessedItem) cache.get(cacheKey);\n                processingLog.add(\"Cache hit for: \" + cacheKey);\n            } else {\n                // Complex transformation logic\n                if (item.getValue() > threshold) {\n                    int transformedValue = item.getValue() * 2;\n                    String category = transformedValue > threshold * 3 ? \"HIGH\" : \"MEDIUM\";\n\n                    processedItem = new ProcessedItem(\n                        item.getId(),\n                        item.getValue(),\n                        transformedValue,\n                        category,\n                        System.currentTimeMillis()\n                    );\n\n                    processedCount++;\n                } else {\n                    int adjustedValue = item.getValue() + threshold;\n                    processedItem = new ProcessedItem(\n                        item.getId(),\n                        item.getValue(),\n                        adjustedValue,\n                        \"LOW\",\n                        System.currentTimeMillis()\n                    );\n                }\n\n                cache.put(cacheKey, processedItem);\n                processingLog.add(\"Processed new item: \" + cacheKey);\n            }",
       "end_line": 55,
       "language": "java",
@@ -189,7 +199,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          37,
+          68
+        ]
+      ],
       "content": "            } else {\n                // Complex transformation logic\n                if (item.getValue() > threshold) {\n                    int transformedValue = item.getValue() * 2;\n                    String category = transformedValue > threshold * 3 ? \"HIGH\" : \"MEDIUM\";\n\n                    processedItem = new ProcessedItem(\n                        item.getId(),\n                        item.getValue(),\n                        transformedValue,\n                        category,\n                        System.currentTimeMillis()\n                    );\n\n                    processedCount++;\n                } else {\n                    int adjustedValue = item.getValue() + threshold;\n                    processedItem = new ProcessedItem(\n                        item.getId(),\n                        item.getValue(),\n                        adjustedValue,\n                        \"LOW\",\n                        System.currentTimeMillis()\n                    );\n                }\n\n                cache.put(cacheKey, processedItem);\n                processingLog.add(\"Processed new item: \" + cacheKey);\n            }",
       "end_line": 55,
       "language": "java",
@@ -302,7 +317,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          188,
+          231
+        ]
+      ],
       "content": "        for (ProcessedItem item : items) {\n            String category = item.getCategory();\n\n            grouped.computeIfAbsent(category, k -> new ArrayList<>()).add(item);\n\n            // Additional analysis for high-value items\n            if (\"HIGH\".equals(category)) {\n                String subCategory = item.getTransformedValue() > 1000 ? \"PREMIUM\" : \"STANDARD\";\n                String key = category + \"_\" + subCategory;\n                grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(item);\n            }\n        }",
       "end_line": 88,
       "language": "java",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_kotlin_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_kotlin_complex_algorithm_extraction.snap
@@ -157,7 +157,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1566,
+          1589
+        ]
+      ],
       "content": "        input.forEachIndexed { index, value ->\n            val cacheKey = \"item_${index}_$value\"\n\n            cache[cacheKey]?.let { cachedItem ->\n                results.add(cachedItem)\n                return@forEachIndexed\n            }\n\n            val processedItem = when {\n                value > threshold -> {\n                    val transformedValue = value * 2\n                    val category = if (transformedValue > threshold * 3) \"HIGH\" else \"MEDIUM\"\n                    val bonusValue = if (transformedValue > 100) transformedValue + 10 else transformedValue\n\n                    ProcessedItem(\n                        id = index,\n                        originalValue = value,\n                        transformedValue = bonusValue,\n                        category = category,\n                        metadata = mutableMapOf(\n                            \"processed\" to true,\n                            \"multiplier\" to 2,\n                            \"processor\" to \"enhanced\"\n                        )\n                    ).also { processedCount++ }\n                }\n                value > 0 -> ProcessedItem(\n                    id = index,\n                    originalValue = value,\n                    transformedValue = value + threshold,\n                    category = \"LOW\",\n                    metadata = mutableMapOf(\n                        \"processed\" to true,\n                        \"adjusted\" to true,\n                        \"processor\" to \"basic\"\n                    )\n                )\n                else -> return@forEachIndexed // skip negative values\n            }\n\n            cache[cacheKey] = processedItem\n            processingLog.add(processedItem)\n            results.add(processedItem)\n        }",
       "end_line": 63,
       "language": "kotlin",
@@ -187,7 +192,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1326,
+          1349
+        ]
+      ],
       "content": "            val processedItem = when {\n                value > threshold -> {\n                    val transformedValue = value * 2\n                    val category = if (transformedValue > threshold * 3) \"HIGH\" else \"MEDIUM\"\n                    val bonusValue = if (transformedValue > 100) transformedValue + 10 else transformedValue\n\n                    ProcessedItem(\n                        id = index,\n                        originalValue = value,\n                        transformedValue = bonusValue,\n                        category = category,\n                        metadata = mutableMapOf(\n                            \"processed\" to true,\n                            \"multiplier\" to 2,\n                            \"processor\" to \"enhanced\"\n                        )\n                    ).also { processedCount++ }\n                }\n                value > 0 -> ProcessedItem(\n                    id = index,\n                    originalValue = value,\n                    transformedValue = value + threshold,\n                    category = \"LOW\",\n                    metadata = mutableMapOf(\n                        \"processed\" to true,\n                        \"adjusted\" to true,\n                        \"processor\" to \"basic\"\n                    )\n                )\n                else -> return@forEachIndexed // skip negative values\n            }",
       "end_line": 58,
       "language": "kotlin",
@@ -344,7 +354,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          505,
+          527
+        ],
+        [
+          675,
+          689
+        ],
+        [
+          939,
+          961
+        ]
+      ],
       "content": "        categoryGroups.forEach { (category, categoryItems) ->\n            val values = categoryItems.map { it.transformedValue.toDouble() }\n            val categoryAnalysis = mapOf(\n                \"count\" to categoryItems.size,\n                \"percentage\" to (categoryItems.size.toDouble() / items.size * 100),\n                \"avg_value\" to values.average(),\n                \"min_value\" to values.minOrNull(),\n                \"max_value\" to values.maxOrNull()\n            ).toMutableMap()\n\n            // Time-based analysis\n            val currentTime = System.currentTimeMillis()\n            val recentItems = categoryItems.filter { currentTime - it.timestamp < 60000 } // last minute\n            if (recentItems.isNotEmpty()) {\n                categoryAnalysis[\"recent_count\"] = recentItems.size\n                categoryAnalysis[\"recent_avg\"] = recentItems.map { it.transformedValue.toDouble() }.average()\n            }\n\n            // High-value analysis\n            val highValueItems = categoryItems.filter { it.transformedValue > 1000 }\n            if (highValueItems.isNotEmpty()) {\n                categoryAnalysis[\"high_value_count\"] = highValueItems.size\n            }\n\n            analysis[category] = categoryAnalysis\n        }",
       "end_line": 108,
       "language": "kotlin",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_python_combined_extraction_new.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_python_combined_extraction_new.snap
@@ -92,7 +92,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          84,
+          104
+        ]
+      ],
       "content": "    for key, value in data.items():\n        if isinstance(value, list):\n            # Process list items\n            processed_list = []\n            for item in value:\n                if isinstance(item, dict) and 'id' in item:\n                    processed_item = {\n                        'id': item['id'],\n                        'processed': True,\n                        'original_keys': list(item.keys())\n                    }\n                    processed_list.append(processed_item)\n\n            processed_items.append({\n                'key': key,\n                'type': 'list',\n                'items': processed_list,\n                'count': len(processed_list)\n            })\n        elif isinstance(value, dict):\n            processed_items.append({\n                'key': key,\n                'type': 'dict',\n                'keys': list(value.keys()),\n                'count': len(value)\n            })",
       "end_line": 45,
       "language": "python",
@@ -102,7 +107,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          48,
+          68
+        ]
+      ],
       "content": "        if isinstance(value, list):\n            # Process list items\n            processed_list = []\n            for item in value:\n                if isinstance(item, dict) and 'id' in item:\n                    processed_item = {\n                        'id': item['id'],\n                        'processed': True,\n                        'original_keys': list(item.keys())\n                    }\n                    processed_list.append(processed_item)\n\n            processed_items.append({\n                'key': key,\n                'type': 'list',\n                'items': processed_list,\n                'count': len(processed_list)\n            })\n        elif isinstance(value, dict):\n            processed_items.append({\n                'key': key,\n                'type': 'dict',\n                'keys': list(value.keys()),\n                'count': len(value)\n            })",
       "end_line": 45,
       "language": "python",
@@ -216,7 +226,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "ErrorHandling",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          175,
+          225
+        ]
+      ],
       "content": "        try:\n            with open(self.config_path, 'r') as file:\n                self.config = json.load(file)\n            return True\n        except Exception:\n            # Default configuration - extractable middle chunk\n            self.config = {\n                'debug': False,\n                'log_level': 'INFO',\n                'database': {\n                    'host': 'localhost',\n                    'port': 0,\n                    'name': 'default_db'\n                },\n                'cache': {\n                    'enabled': True,\n                    'ttl': 0,\n                    'max_size': 1000\n                },\n                'features': {\n                    'analytics': True,\n                    'notifications': False,\n                    'beta_features': False\n                }\n            }\n            return False",
       "end_line": 86,
       "language": "python",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_python_function_extraction_new.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_python_function_extraction_new.snap
@@ -92,7 +92,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          146,
+          169
+        ]
+      ],
       "content": "    for item in data:\n        if isinstance(item, dict):\n            value = item.get('value', 0)\n        else:\n            value = item\n\n        # Apply transformations\n        if value > threshold:\n            transformed = value * 2\n            result.append({\n                'original': value,\n                'transformed': transformed,\n                'ratio': transformed / value\n            })\n            processed_count += 1\n        elif value > 0:\n            result.append({\n                'original': value,\n                'transformed': value + threshold,\n                'ratio': (value + threshold) / value\n            })",
       "end_line": 32,
       "language": "python",
@@ -195,7 +200,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          81,
+          135
+        ],
+        [
+          327,
+          338
+        ],
+        [
+          515,
+          534
+        ]
+      ],
       "content": "    for idx, item in enumerate(input_data):\n        key = f\"item_{idx}\"\n\n        # Complex conditional logic - extractable middle chunk\n        if key in cache:\n            cached_result = cache[key]\n            if cached_result['valid']:\n                results.append(cached_result['data'])\n            else:\n                # Recompute\n                new_result = item * 2 + 1\n                cache[key] = {'data': new_result, 'valid': True}\n                results.append(new_result)\n        else:\n            # First computation\n            computed = item ** 2 if item > 5 else item * 3\n            cache[key] = {'data': computed, 'valid': True}\n            results.append(computed)",
       "end_line": 64,
       "language": "python",
@@ -205,7 +223,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          191,
+          202
+        ],
+        [
+          379,
+          398
+        ]
+      ],
       "content": "        if key in cache:\n            cached_result = cache[key]\n            if cached_result['valid']:\n                results.append(cached_result['data'])\n            else:\n                # Recompute\n                new_result = item * 2 + 1\n                cache[key] = {'data': new_result, 'valid': True}\n                results.append(new_result)\n        else:\n            # First computation\n            computed = item ** 2 if item > 5 else item * 3\n            cache[key] = {'data': computed, 'valid': True}\n            results.append(computed)",
       "end_line": 64,
       "language": "python",
@@ -215,7 +242,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          127,
+          138
+        ]
+      ],
       "content": "            if cached_result['valid']:\n                results.append(cached_result['data'])\n            else:\n                # Recompute\n                new_result = item * 2 + 1\n                cache[key] = {'data': new_result, 'valid': True}\n                results.append(new_result)",
       "end_line": 59,
       "language": "python",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_ruby_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_ruby_complex_algorithm_extraction.snap
@@ -209,7 +209,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1439,
+          1461
+        ]
+      ],
       "content": "    input.each_with_index do |value, index|\n      cache_key = \"item_#{index}_#{value}\"\n\n      if @cache.key?(cache_key)\n        results << @cache[cache_key]\n        next\n      end\n\n      processed_item = if value > @threshold\n                         transformed_value = value * 2\n                         category = transformed_value > @threshold * 3 ? 'HIGH' : 'MEDIUM'\n                         bonus_value = transformed_value > 100 ? transformed_value + 10 : transformed_value\n\n                         ProcessedItem.new(\n                           index,\n                           value,\n                           bonus_value,\n                           category,\n                           {\n                             processed: true,\n                             multiplier: 0,\n                             processor: 'enhanced'\n                           }\n                         ).tap { processed_count += 1 }\n                       elsif value > 0\n                         ProcessedItem.new(\n                           index,\n                           value,\n                           value + @threshold,\n                           'LOW',\n                           {\n                             processed: true,\n                             adjusted: true,\n                             processor: 'basic'\n                           }\n                         )\n                       else\n                         next # skip negative values\n                       end\n\n      @cache[cache_key] = processed_item\n      @processing_log << processed_item\n      results << processed_item\n    end",
       "end_line": 70,
       "language": "ruby",
@@ -229,7 +234,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1258,
+          1280
+        ]
+      ],
       "content": "      processed_item = if value > @threshold\n                         transformed_value = value * 2\n                         category = transformed_value > @threshold * 3 ? 'HIGH' : 'MEDIUM'\n                         bonus_value = transformed_value > 100 ? transformed_value + 10 : transformed_value\n\n                         ProcessedItem.new(\n                           index,\n                           value,\n                           bonus_value,\n                           category,\n                           {\n                             processed: true,\n                             multiplier: 0,\n                             processor: 'enhanced'\n                           }\n                         ).tap { processed_count += 1 }\n                       elsif value > 0\n                         ProcessedItem.new(\n                           index,\n                           value,\n                           value + @threshold,\n                           'LOW',\n                           {\n                             processed: true,\n                             adjusted: true,\n                             processor: 'basic'\n                           }\n                         )\n                       else\n                         next # skip negative values\n                       end",
       "end_line": 65,
       "language": "ruby",
@@ -259,7 +269,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          173,
+          200
+        ]
+      ],
       "content": "    if processed_count > 0\n      average = results.sum(&:transformed_value).to_f / results.size\n      puts \"Processing complete. Average: #{format('%.2f', average)}\"\n\n      # Add processing statistics\n      results.each { |item| item.metadata[:processing_average] = average }\n    end",
       "end_line": 79,
       "language": "ruby",
@@ -306,7 +321,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          367,
+          388
+        ],
+        [
+          508,
+          521
+        ],
+        [
+          780,
+          801
+        ]
+      ],
       "content": "    category_groups.each do |category, category_items|\n      values = category_items.map(&:transformed_value)\n      category_analysis = {\n        count: category_items.size,\n        percentage: (category_items.size.to_f / items.size * 100),\n        avg_value: values.sum.to_f / values.size,\n        min_value: values.min,\n        max_value: values.max\n      }\n\n      # Time-based analysis\n      current_time = Time.now\n      recent_items = category_items.select { |item| current_time - item.timestamp < 60 } # last minute\n      unless recent_items.empty?\n        recent_values = recent_items.map(&:transformed_value)\n        category_analysis[:recent_count] = recent_items.size\n        category_analysis[:recent_avg] = recent_values.sum.to_f / recent_values.size\n      end\n\n      # High-value analysis\n      high_value_items = category_items.select { |item| item.transformed_value > 1000 }\n      category_analysis[:high_value_count] = high_value_items.size unless high_value_items.empty?\n\n      analysis[category] = category_analysis\n    end",
       "end_line": 113,
       "language": "ruby",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_rust_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_rust_complex_algorithm_extraction.snap
@@ -70,7 +70,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          260,
+          300
+        ]
+      ],
       "content": "    for (index, value) in input.iter().enumerate() {\n        let key = format!(\"item_{}\", index);\n\n        if *value > threshold {\n            let processed = value * 2;\n            result.insert(key.clone(), processed);\n            counter += 1;\n\n            // Additional processing for high values\n            if processed > 100 {\n                let bonus_key = format!(\"{}_bonus\", key);\n                result.insert(bonus_key, processed / 10);\n            }\n        } else if *value > 0 {\n            let adjusted = value + threshold;\n            result.insert(key, adjusted);\n            counter += 1;\n        }\n    }",
       "end_line": 27,
       "language": "rust",
@@ -80,7 +85,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          161,
+          201
+        ]
+      ],
       "content": "        if *value > threshold {\n            let processed = value * 2;\n            result.insert(key.clone(), processed);\n            counter += 1;\n\n            // Additional processing for high values\n            if processed > 100 {\n                let bonus_key = format!(\"{}_bonus\", key);\n                result.insert(bonus_key, processed / 10);\n            }\n        }",
       "end_line": 22,
       "language": "rust",
@@ -90,7 +100,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          161,
+          201
+        ]
+      ],
       "content": "        if *value > threshold {\n            let processed = value * 2;\n            result.insert(key.clone(), processed);\n            counter += 1;\n\n            // Additional processing for high values\n            if processed > 100 {\n                let bonus_key = format!(\"{}_bonus\", key);\n                result.insert(bonus_key, processed / 10);\n            }\n        } else if *value > 0 {\n            let adjusted = value + threshold;\n            result.insert(key, adjusted);\n            counter += 1;\n        }",
       "end_line": 26,
       "language": "rust",
@@ -169,7 +184,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          547,
+          572
+        ]
+      ],
       "content": "    for (pattern_idx, pattern) in patterns.iter().enumerate() {\n        let mut search_start = 0;\n\n        while let Some(pos) = text[search_start..].find(pattern) {\n            let absolute_pos = search_start + pos;\n            let context_start = absolute_pos.saturating_sub(10);\n            let context_end = (absolute_pos + pattern.len() + 10).min(text.len());\n            let context = text[context_start..context_end].to_string();\n\n            matches.push((absolute_pos, context));\n            search_start = absolute_pos + 1;\n\n            // Prevent infinite loops\n            if search_start >= text.len() {\n                break;\n            }\n        }\n    }",
       "end_line": 60,
       "language": "rust",
@@ -179,7 +199,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          448,
+          473
+        ]
+      ],
       "content": "        while let Some(pos) = text[search_start..].find(pattern) {\n            let absolute_pos = search_start + pos;\n            let context_start = absolute_pos.saturating_sub(10);\n            let context_end = (absolute_pos + pattern.len() + 10).min(text.len());\n            let context = text[context_start..context_end].to_string();\n\n            matches.push((absolute_pos, context));\n            search_start = absolute_pos + 1;\n\n            // Prevent infinite loops\n            if search_start >= text.len() {\n                break;\n            }\n        }",
       "end_line": 59,
       "language": "rust",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_rust_struct_with_complex_impl.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_rust_struct_with_complex_impl.snap
@@ -78,7 +78,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          14,
+          66
+        ],
+        [
+          244,
+          295
+        ]
+      ],
       "content": "    {\n        // Cache management logic - extractable middle chunk\n        if let Some(value) = self.cache.get(key) {\n            *self.access_count.entry(key.to_string()).or_insert(0) += 1;\n            return value.clone();\n        }\n\n        // Check if cache is full and evict least used item\n        if self.cache.len() >= self.max_size {\n            if let Some(lru_key) = self.find_least_used_key() {\n                self.cache.remove(&lru_key);\n                self.access_count.remove(&lru_key);\n            }\n        }\n\n        let computed_value = compute();\n        self.cache.insert(key.to_string(), computed_value.clone());\n        self.access_count.insert(key.to_string(), 1);\n        computed_value\n    }",
       "end_line": 40,
       "language": "rust",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_scala_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_scala_complex_algorithm_extraction.snap
@@ -137,7 +137,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1367,
+          1390
+        ]
+      ],
       "content": "    input.zipWithIndex.foreach { case (value, index) =>\n      val cacheKey = s\"item_${index}_$value\"\n\n      cache.get(cacheKey) match {\n        case Some(cachedItem) =>\n          results += cachedItem\n        case None =>\n          val processedItem = value match {\n            case v if v > threshold =>\n              val transformedValue = v * 2\n              val category = if (transformedValue > threshold * 3) \"HIGH\" else \"MEDIUM\"\n              val bonusValue = if (transformedValue > 100) transformedValue + 10 else transformedValue\n\n              processedCount += 1\n              ProcessedItem(\n                id = index,\n                originalValue = v,\n                transformedValue = bonusValue,\n                category = category,\n                metadata = mutable.Map(\n                  \"processed\" -> true,\n                  \"multiplier\" -> 2,\n                  \"processor\" -> \"enhanced\"\n                )\n              )\n\n            case v if v > 0 =>\n              ProcessedItem(\n                id = index,\n                originalValue = v,\n                transformedValue = v + threshold,\n                category = \"LOW\",\n                metadata = mutable.Map(\n                  \"processed\" -> true,\n                  \"adjusted\" -> true,\n                  \"processor\" -> \"basic\"\n                )\n              )\n\n            case _ => // skip negative values\n              null\n          }\n\n          if (processedItem != null) {\n            cache(cacheKey) = processedItem\n            processingLog += processedItem\n            results += processedItem\n          }\n      }\n    }",
       "end_line": 73,
       "language": "scala",
@@ -147,7 +152,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1265,
+          1288
+        ]
+      ],
       "content": "      cache.get(cacheKey) match {\n        case Some(cachedItem) =>\n          results += cachedItem\n        case None =>\n          val processedItem = value match {\n            case v if v > threshold =>\n              val transformedValue = v * 2\n              val category = if (transformedValue > threshold * 3) \"HIGH\" else \"MEDIUM\"\n              val bonusValue = if (transformedValue > 100) transformedValue + 10 else transformedValue\n\n              processedCount += 1\n              ProcessedItem(\n                id = index,\n                originalValue = v,\n                transformedValue = bonusValue,\n                category = category,\n                metadata = mutable.Map(\n                  \"processed\" -> true,\n                  \"multiplier\" -> 2,\n                  \"processor\" -> \"enhanced\"\n                )\n              )\n\n            case v if v > 0 =>\n              ProcessedItem(\n                id = index,\n                originalValue = v,\n                transformedValue = v + threshold,\n                category = \"LOW\",\n                metadata = mutable.Map(\n                  \"processed\" -> true,\n                  \"adjusted\" -> true,\n                  \"processor\" -> \"basic\"\n                )\n              )\n\n            case _ => // skip negative values\n              null\n          }\n\n          if (processedItem != null) {\n            cache(cacheKey) = processedItem\n            processingLog += processedItem\n            results += processedItem\n          }\n      }",
       "end_line": 72,
       "language": "scala",
@@ -157,7 +167,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1145,
+          1168
+        ]
+      ],
       "content": "          val processedItem = value match {\n            case v if v > threshold =>\n              val transformedValue = v * 2\n              val category = if (transformedValue > threshold * 3) \"HIGH\" else \"MEDIUM\"\n              val bonusValue = if (transformedValue > 100) transformedValue + 10 else transformedValue\n\n              processedCount += 1\n              ProcessedItem(\n                id = index,\n                originalValue = v,\n                transformedValue = bonusValue,\n                category = category,\n                metadata = mutable.Map(\n                  \"processed\" -> true,\n                  \"multiplier\" -> 2,\n                  \"processor\" -> \"enhanced\"\n                )\n              )\n\n            case v if v > 0 =>\n              ProcessedItem(\n                id = index,\n                originalValue = v,\n                transformedValue = v + threshold,\n                category = \"LOW\",\n                metadata = mutable.Map(\n                  \"processed\" -> true,\n                  \"adjusted\" -> true,\n                  \"processor\" -> \"basic\"\n                )\n              )\n\n            case _ => // skip negative values\n              null\n          }",
       "end_line": 65,
       "language": "scala",
@@ -217,7 +232,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          178,
+          206
+        ]
+      ],
       "content": "    if (processedCount > 0) {\n      val average = results.map(_.transformedValue).sum.toDouble / results.size\n      println(f\"Processing complete. Average: $average%.2f\")\n\n      // Add processing statistics\n      results.foreach(_.metadata(\"processing_average\") = average)\n    }",
       "end_line": 82,
       "language": "scala",
@@ -250,7 +270,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          428,
+          450
+        ],
+        [
+          939,
+          961
+        ]
+      ],
       "content": "    val analysis = categoryGroups.map { case (category, categoryItems) =>\n      val values = categoryItems.map(_.transformedValue)\n      val categoryAnalysis = Map(\n        \"count\" -> categoryItems.size,\n        \"percentage\" -> (categoryItems.size.toDouble / items.size * 100),\n        \"avg_value\" -> (values.sum.toDouble / values.size),\n        \"min_value\" -> values.min,\n        \"max_value\" -> values.max\n      ) ++ {\n        // Time-based analysis\n        val currentTime = Instant.now()\n        val recentItems = categoryItems.filter { item =>\n          java.time.Duration.between(item.timestamp, currentTime).getSeconds < 60\n        }\n\n        if (recentItems.nonEmpty) {\n          val recentValues = recentItems.map(_.transformedValue)\n          Map(\n            \"recent_count\" -> recentItems.size,\n            \"recent_avg\" -> (recentValues.sum.toDouble / recentValues.size)\n          )\n        } else Map.empty\n      } ++ {\n        // High-value analysis\n        val highValueItems = categoryItems.filter(_.transformedValue > 1000)\n        if (highValueItems.nonEmpty) {\n          Map(\"high_value_count\" -> highValueItems.size)\n        } else Map.empty\n      }\n\n      category -> categoryAnalysis\n    }",
       "end_line": 122,
       "language": "scala",
@@ -270,7 +299,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          21,
+          43
+        ]
+      ],
       "content": "      ) ++ {\n        // Time-based analysis\n        val currentTime = Instant.now()\n        val recentItems = categoryItems.filter { item =>\n          java.time.Duration.between(item.timestamp, currentTime).getSeconds < 60\n        }\n\n        if (recentItems.nonEmpty) {\n          val recentValues = recentItems.map(_.transformedValue)\n          Map(\n            \"recent_count\" -> recentItems.size,\n            \"recent_avg\" -> (recentValues.sum.toDouble / recentValues.size)\n          )\n        } else Map.empty\n      }",
       "end_line": 113,
       "language": "scala",
@@ -310,7 +344,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          21,
+          43
+        ]
+      ],
       "content": "      } ++ {\n        // High-value analysis\n        val highValueItems = categoryItems.filter(_.transformedValue > 1000)\n        if (highValueItems.nonEmpty) {\n          Map(\"high_value_count\" -> highValueItems.size)\n        } else Map.empty\n      }",
       "end_line": 119,
       "language": "scala",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_swift_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_swift_complex_algorithm_extraction.snap
@@ -187,7 +187,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1497,
+          1520
+        ]
+      ],
       "content": "        for (index, value) in input.enumerated() {\n            let cacheKey = \"item_\\(index)_\\(value)\"\n\n            if let cachedItem = cache[cacheKey] {\n                results.append(cachedItem)\n                continue\n            }\n\n            let processedItem: ProcessedItem?\n            if value > threshold {\n                let transformedValue = value * 2\n                let category = transformedValue > threshold * 3 ? \"HIGH\" : \"MEDIUM\"\n                let bonusValue = transformedValue > 100 ? transformedValue + 10 : transformedValue\n\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: bonusValue,\n                    category: category,\n                    metadata: [\n                        \"processed\": true,\n                        \"multiplier\": 0,\n                        \"processor\": \"enhanced\"\n                    ]\n                )\n                processedCount += 1\n            } else if value > 0 {\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: value + threshold,\n                    category: \"LOW\",\n                    metadata: [\n                        \"processed\": true,\n                        \"adjusted\": true,\n                        \"processor\": \"basic\"\n                    ]\n                )\n            } else {\n                continue // skip negative values\n            }\n\n            if let item = processedItem {\n                cache[cacheKey] = item\n                processingLog.append(item)\n                results.append(item)\n            }\n        }",
       "end_line": 83,
       "language": "swift",
@@ -197,7 +202,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1446,
+          1469
+        ]
+      ],
       "content": "            let cacheKey = \"item_\\(index)_\\(value)\"\n\n            if let cachedItem = cache[cacheKey] {\n                results.append(cachedItem)\n                continue\n            }\n\n            let processedItem: ProcessedItem?\n            if value > threshold {\n                let transformedValue = value * 2\n                let category = transformedValue > threshold * 3 ? \"HIGH\" : \"MEDIUM\"\n                let bonusValue = transformedValue > 100 ? transformedValue + 10 : transformedValue\n\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: bonusValue,\n                    category: category,\n                    metadata: [\n                        \"processed\": true,\n                        \"multiplier\": 0,\n                        \"processor\": \"enhanced\"\n                    ]\n                )\n                processedCount += 1\n            } else if value > 0 {\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: value + threshold,\n                    category: \"LOW\",\n                    metadata: [\n                        \"processed\": true,\n                        \"adjusted\": true,\n                        \"processor\": \"basic\"\n                    ]\n                )\n            } else {\n                continue // skip negative values\n            }\n\n            if let item = processedItem {\n                cache[cacheKey] = item\n                processingLog.append(item)\n                results.append(item)\n            }\n        ",
       "end_line": 83,
       "language": "swift",
@@ -227,7 +237,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          1214,
+          1237
+        ]
+      ],
       "content": "            if value > threshold {\n                let transformedValue = value * 2\n                let category = transformedValue > threshold * 3 ? \"HIGH\" : \"MEDIUM\"\n                let bonusValue = transformedValue > 100 ? transformedValue + 10 : transformedValue\n\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: bonusValue,\n                    category: category,\n                    metadata: [\n                        \"processed\": true,\n                        \"multiplier\": 0,\n                        \"processor\": \"enhanced\"\n                    ]\n                )\n                processedCount += 1\n            } else if value > 0 {\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: value + threshold,\n                    category: \"LOW\",\n                    metadata: [\n                        \"processed\": true,\n                        \"adjusted\": true,\n                        \"processor\": \"basic\"\n                    ]\n                )\n            } else {\n                continue // skip negative values\n            }",
       "end_line": 76,
       "language": "swift",
@@ -257,7 +272,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          496,
+          519
+        ]
+      ],
       "content": "            } else if value > 0 {\n                processedItem = ProcessedItem(\n                    id: index,\n                    originalValue: value,\n                    transformedValue: value + threshold,\n                    category: \"LOW\",\n                    metadata: [\n                        \"processed\": true,\n                        \"adjusted\": true,\n                        \"processor\": \"basic\"\n                    ]\n                )\n            } else {\n                continue // skip negative values\n            }",
       "end_line": 76,
       "language": "swift",
@@ -287,7 +307,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          25,
+          48
+        ]
+      ],
       "content": "                continue // skip negative values\n            ",
       "end_line": 76,
       "language": "swift",
@@ -317,7 +342,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          238,
+          266
+        ]
+      ],
       "content": "        if processedCount > 0 {\n            let average = Double(results.map { $0.transformedValue }.reduce(0, +)) / Double(results.count)\n            print(\"Processing complete. Average: \\(String(format: \"%.2f\", average))\")\n\n            // Add processing statistics\n            for i in 0..<results.count {\n                results[i].metadata[\"processing_average\"] = average\n            }\n        }",
       "end_line": 94,
       "language": "swift",
@@ -327,7 +357,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          206,
+          234
+        ]
+      ],
       "content": "            let average = Double(results.map { $0.transformedValue }.reduce(0, +)) / Double(results.count)\n            print(\"Processing complete. Average: \\(String(format: \"%.2f\", average))\")\n\n            // Add processing statistics\n            for i in 0..<results.count {\n                results[i].metadata[\"processing_average\"] = average\n            }\n        ",
       "end_line": 94,
       "language": "swift",
@@ -394,7 +429,24 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          134,
+          186
+        ],
+        [
+          700,
+          722
+        ],
+        [
+          864,
+          878
+        ],
+        [
+          1200,
+          1222
+        ]
+      ],
       "content": "        var analysis: [String: [String: Any]] = [:]\n        let categoryGroups = Dictionary(grouping: items) { $0.category }\n\n        // Pattern analysis logic - extractable middle chunk\n        for (category, categoryItems) in categoryGroups {\n            let values = categoryItems.map { $0.transformedValue }\n            var categoryAnalysis: [String: Any] = [\n                \"count\": categoryItems.count,\n                \"percentage\": Double(categoryItems.count) / Double(items.count) * 100,\n                \"avg_value\": Double(values.reduce(0, +)) / Double(values.count),\n                \"min_value\": values.min() ?? 0,\n                \"max_value\": values.max() ?? 0\n            ]\n\n            // Time-based analysis\n            let currentTime = Date()\n            let recentItems = categoryItems.filter { currentTime.timeIntervalSince($0.timestamp) < 60 } // last minute\n            if !recentItems.isEmpty {\n                let recentValues = recentItems.map { $0.transformedValue }\n                categoryAnalysis[\"recent_count\"] = recentItems.count\n                categoryAnalysis[\"recent_avg\"] = Double(recentValues.reduce(0, +)) / Double(recentValues.count)\n            }\n\n            // High-value analysis\n            let highValueItems = categoryItems.filter { $0.transformedValue > 1000 }\n            if !highValueItems.isEmpty {\n                categoryAnalysis[\"high_value_count\"] = highValueItems.count\n            }\n\n            analysis[category] = categoryAnalysis\n        }\n\n        analysis[\"total_items\"] = items.count\n        analysis[\"processing_time\"] = Date().timeIntervalSince1970\n\n        return analysis\n    ",
       "end_line": 136,
       "language": "swift",
@@ -404,7 +456,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          513,
+          535
+        ],
+        [
+          677,
+          691
+        ],
+        [
+          1013,
+          1035
+        ]
+      ],
       "content": "        for (category, categoryItems) in categoryGroups {\n            let values = categoryItems.map { $0.transformedValue }\n            var categoryAnalysis: [String: Any] = [\n                \"count\": categoryItems.count,\n                \"percentage\": Double(categoryItems.count) / Double(items.count) * 100,\n                \"avg_value\": Double(values.reduce(0, +)) / Double(values.count),\n                \"min_value\": values.min() ?? 0,\n                \"max_value\": values.max() ?? 0\n            ]\n\n            // Time-based analysis\n            let currentTime = Date()\n            let recentItems = categoryItems.filter { currentTime.timeIntervalSince($0.timestamp) < 60 } // last minute\n            if !recentItems.isEmpty {\n                let recentValues = recentItems.map { $0.transformedValue }\n                categoryAnalysis[\"recent_count\"] = recentItems.count\n                categoryAnalysis[\"recent_avg\"] = Double(recentValues.reduce(0, +)) / Double(recentValues.count)\n            }\n\n            // High-value analysis\n            let highValueItems = categoryItems.filter { $0.transformedValue > 1000 }\n            if !highValueItems.isEmpty {\n                categoryAnalysis[\"high_value_count\"] = highValueItems.count\n            }\n\n            analysis[category] = categoryAnalysis\n        }",
       "end_line": 130,
       "language": "swift",
@@ -414,7 +479,20 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          455,
+          477
+        ],
+        [
+          619,
+          633
+        ],
+        [
+          955,
+          977
+        ]
+      ],
       "content": "            let values = categoryItems.map { $0.transformedValue }\n            var categoryAnalysis: [String: Any] = [\n                \"count\": categoryItems.count,\n                \"percentage\": Double(categoryItems.count) / Double(items.count) * 100,\n                \"avg_value\": Double(values.reduce(0, +)) / Double(values.count),\n                \"min_value\": values.min() ?? 0,\n                \"max_value\": values.max() ?? 0\n            ]\n\n            // Time-based analysis\n            let currentTime = Date()\n            let recentItems = categoryItems.filter { currentTime.timeIntervalSince($0.timestamp) < 60 } // last minute\n            if !recentItems.isEmpty {\n                let recentValues = recentItems.map { $0.transformedValue }\n                categoryAnalysis[\"recent_count\"] = recentItems.count\n                categoryAnalysis[\"recent_avg\"] = Double(recentValues.reduce(0, +)) / Double(recentValues.count)\n            }\n\n            // High-value analysis\n            let highValueItems = categoryItems.filter { $0.transformedValue > 1000 }\n            if !highValueItems.isEmpty {\n                categoryAnalysis[\"high_value_count\"] = highValueItems.count\n            }\n\n            analysis[category] = categoryAnalysis\n        ",
       "end_line": 130,
       "language": "swift",

--- a/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_typescript_complex_algorithm_extraction.snap
+++ b/tests/integration/languages/snapshots/r#mod__integration__languages__extractor__test_typescript_complex_algorithm_extraction.snap
@@ -191,7 +191,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          34,
+          65
+        ],
+        [
+          470,
+          510
+        ]
+      ],
       "content": "            try {\n                // Complex transformation logic\n                let transformedValue: number;\n                let category: 'LOW' | 'MEDIUM' | 'HIGH';\n                let processor: string;\n\n                if (item.value > this.threshold) {\n                    transformedValue = item.value * 2;\n                    category = transformedValue > this.threshold * 3 ? 'HIGH' : 'MEDIUM';\n                    processor = 'enhanced';\n\n                    // Additional processing for high values\n                    if (category === 'HIGH' && item.metadata?.boost) {\n                        transformedValue *= 1.5;\n                        processor = 'boosted';\n                    }\n                } else {\n                    transformedValue = item.value + this.threshold;\n                    category = 'LOW';\n                    processor = 'basic';\n                }\n\n                const processedItem: ProcessedItem = {\n                    ...item,\n                    transformedValue,\n                    category,\n                    timestamp: Date.now(),\n                    processingInfo: {\n                        cached: false,\n                        processor,\n                        duration: Date.now() - startTime\n                    }\n                };\n\n                this.cache.set(cacheKey, processedItem);\n                results.push(processedItem);\n                this.stats.processed++;\n\n            }",
       "end_line": 89,
       "language": "typescript",
@@ -201,7 +210,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "ErrorHandling",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          34,
+          65
+        ],
+        [
+          470,
+          510
+        ]
+      ],
       "content": "            try {\n                // Complex transformation logic\n                let transformedValue: number;\n                let category: 'LOW' | 'MEDIUM' | 'HIGH';\n                let processor: string;\n\n                if (item.value > this.threshold) {\n                    transformedValue = item.value * 2;\n                    category = transformedValue > this.threshold * 3 ? 'HIGH' : 'MEDIUM';\n                    processor = 'enhanced';\n\n                    // Additional processing for high values\n                    if (category === 'HIGH' && item.metadata?.boost) {\n                        transformedValue *= 1.5;\n                        processor = 'boosted';\n                    }\n                } else {\n                    transformedValue = item.value + this.threshold;\n                    category = 'LOW';\n                    processor = 'basic';\n                }\n\n                const processedItem: ProcessedItem = {\n                    ...item,\n                    transformedValue,\n                    category,\n                    timestamp: Date.now(),\n                    processingInfo: {\n                        cached: false,\n                        processor,\n                        duration: Date.now() - startTime\n                    }\n                };\n\n                this.cache.set(cacheKey, processedItem);\n                results.push(processedItem);\n                this.stats.processed++;\n\n            } catch (error) {\n                this.stats.errors++;\n                console.error(`Error processing item ${item.id}:`, error);\n            }",
       "end_line": 92,
       "language": "typescript",
@@ -211,7 +229,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "CodeBlock",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          261,
+          301
+        ]
+      ],
       "content": "                if (item.value > this.threshold) {\n                    transformedValue = item.value * 2;\n                    category = transformedValue > this.threshold * 3 ? 'HIGH' : 'MEDIUM';\n                    processor = 'enhanced';\n\n                    // Additional processing for high values\n                    if (category === 'HIGH' && item.metadata?.boost) {\n                        transformedValue *= 1.5;\n                        processor = 'boosted';\n                    }\n                }",
       "end_line": 67,
       "language": "typescript",
@@ -221,7 +244,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Conditional",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          261,
+          301
+        ]
+      ],
       "content": "                if (item.value > this.threshold) {\n                    transformedValue = item.value * 2;\n                    category = transformedValue > this.threshold * 3 ? 'HIGH' : 'MEDIUM';\n                    processor = 'enhanced';\n\n                    // Additional processing for high values\n                    if (category === 'HIGH' && item.metadata?.boost) {\n                        transformedValue *= 1.5;\n                        processor = 'boosted';\n                    }\n                } else {\n                    transformedValue = item.value + this.threshold;\n                    category = 'LOW';\n                    processor = 'basic';\n                }",
       "end_line": 71,
       "language": "typescript",
@@ -314,7 +342,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          753,
+          775
+        ],
+        [
+          890,
+          904
+        ]
+      ],
       "content": "        for (const [category, categoryItems] of Object.entries(categoryGroups)) {\n            const values = categoryItems.map(item => item.transformedValue);\n            const average = values.reduce((sum, val) => sum + val, 0) / values.length;\n            const max = Math.max(...values);\n            const min = Math.min(...values);\n\n            analysis.categoryDistribution = {\n                ...analysis.categoryDistribution as object,\n                [category]: {\n                    count: categoryItems.length,\n                    percentage: (categoryItems.length / items.length) * 100,\n                    avgValue: average,\n                    minValue: min,\n                    maxValue: max\n                }\n            };\n\n            // Time-based analysis\n            const recentItems = categoryItems.filter(\n                item => Date.now() - item.timestamp < 60000 // last minute\n            );\n\n            if (recentItems.length > 0) {\n                analysis.averageValues = {\n                    ...analysis.averageValues as object,\n                    [`${category}_recent`]: recentItems.length\n                };\n            }\n        }",
       "end_line": 144,
       "language": "typescript",
@@ -324,7 +361,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "FunctionCall",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          114,
+          128
+        ]
+      ],
       "content": "            const recentItems = categoryItems.filter(\n                item => Date.now() - item.timestamp < 60000 // last minute\n            )",
       "end_line": 136,
       "language": "typescript",
@@ -373,7 +415,16 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Lambda",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          113,
+          159
+        ],
+        [
+          462,
+          501
+        ]
+      ],
       "content": "    return (data: unknown): data is T => {\n        if (!data || typeof data !== 'object') return false;\n\n        // Validation logic - extractable middle chunk\n        for (const [key, validator] of Object.entries(schema)) {\n            const value = (data as Record<string, unknown>)[key];\n\n            if (!validator(value)) {\n                console.warn(`Validation failed for field ${key}:`, value);\n                return false;\n            }\n\n            // Additional type-specific validations\n            if (typeof value === 'string' && value.length === 0) {\n                console.warn(`Empty string not allowed for field ${key}`);\n                return false;\n            }\n\n            if (typeof value === 'number' && !Number.isFinite(value)) {\n                console.warn(`Invalid number for field ${key}:`, value);\n                return false;\n            }\n        }\n\n        return true;\n    }",
       "end_line": 177,
       "language": "typescript",
@@ -383,7 +434,12 @@ expression: "serde_json::to_string_pretty(&snapshot_data).unwrap()"
     },
     {
       "chunk_type": "Loop",
-      "comment_ranges": [],
+      "comment_ranges": [
+        [
+          302,
+          341
+        ]
+      ],
       "content": "        for (const [key, validator] of Object.entries(schema)) {\n            const value = (data as Record<string, unknown>)[key];\n\n            if (!validator(value)) {\n                console.warn(`Validation failed for field ${key}:`, value);\n                return false;\n            }\n\n            // Additional type-specific validations\n            if (typeof value === 'string' && value.length === 0) {\n                console.warn(`Empty string not allowed for field ${key}`);\n                return false;\n            }\n\n            if (typeof value === 'number' && !Number.isFinite(value)) {\n                console.warn(`Invalid number for field ${key}:`, value);\n                return false;\n            }\n        }",
       "end_line": 174,
       "language": "typescript",


### PR DESCRIPTION
## Summary
- Fixed bug where comment ranges in middle chunks were not properly detected
- The issue was caused by passing an empty byte-to-char cache array to `extract_comment_ranges` instead of the properly constructed cache
- This resulted in incorrect comment position calculations, causing comments to not be recognized as skippable during typing

## Changes
- Modified `src/extractor/core/extractor.rs` to use the correct `chunk_byte_to_char_cache` when extracting comment ranges for middle chunks
- Updated snapshot tests to reflect the correct comment range detection

## Test Plan
- [x] All existing tests pass
- [x] 16 snapshot tests updated to show correct comment range detection
- [x] Comments in middle chunks are now properly recognized and marked as skippable

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy detecting and highlighting comment ranges in very large files, eliminating misaligned selections and off-by-one character issues.
  * Reduced rare errors when navigating or interacting with comments in oversized documents, improving stability in large-file workflows.
  * Increased consistency of character-position handling across large content, yielding more reliable annotations and fewer parsing glitches without requiring user changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->