### PR TITLE
fix: refresh repository list in records screen to prevent unknown display

### DIFF
--- a/src/game/screens/records_screen.rs
+++ b/src/game/screens/records_screen.rs
@@ -281,6 +281,9 @@ impl RecordsScreen {
     fn refresh_sessions(&mut self) -> Result<()> {
         let session_repo = SessionRepository::new()?;
 
+        // Refresh repository list to include any newly created repositories
+        self.repositories = session_repo.get_all_repositories()?;
+
         // Use the improved database filtering method
         let sessions = session_repo.get_sessions_filtered(
             self.filter_state.repository_filter,


### PR DESCRIPTION
## Summary
- Fix RecordsScreen showing "Unknown" for recently played repositories
- Refresh repository list when updating session display data

## Problem
RecordsScreen was displaying "Unknown" for recently played repositories. This occurred because newly added repository information after session execution was not included in the cached repository data retrieved during RecordsScreen initialization.

## Solution
Modified the `refresh_sessions` method to refresh repository information to the latest state every time the session list is updated.

## Test plan
- [x] cargo check
- [x] cargo test (25 passed)
- [x] cargo clippy (no warnings)
- [x] cargo fmt

🤖 Generated with [Claude Code](https://claude.ai/code)