### PR TITLE
feat: reorder Game Help sections to show Code Challenge Types before Typing Tips

### DIFF
--- a/src/game/screens/help_screen.rs
+++ b/src/game/screens/help_screen.rs
@@ -291,32 +291,6 @@ impl HelpScreen {
             )),
             Line::from(""),
             Line::from(vec![Span::styled(
-                "Typing Tips:",
-                Style::default().fg(Colors::title()).bold(),
-            )]),
-            Line::from(""),
-            Line::from(Span::styled(
-                "• Focus on accuracy over speed initially",
-                Style::default().fg(Colors::text()),
-            )),
-            Line::from(Span::styled(
-                "• Use proper finger positioning",
-                Style::default().fg(Colors::text()),
-            )),
-            Line::from(Span::styled(
-                "• Practice regularly to improve muscle memory",
-                Style::default().fg(Colors::text()),
-            )),
-            Line::from(Span::styled(
-                "• Don't look at the keyboard while typing",
-                Style::default().fg(Colors::text()),
-            )),
-            Line::from(Span::styled(
-                "• Take breaks to avoid fatigue",
-                Style::default().fg(Colors::text()),
-            )),
-            Line::from(""),
-            Line::from(vec![Span::styled(
                 "Code Challenge Types:",
                 Style::default().fg(Colors::title()).bold(),
             )]),
@@ -348,6 +322,32 @@ impl HelpScreen {
             )),
             Line::from(Span::styled(
                 "• Control flow (loops, conditionals)",
+                Style::default().fg(Colors::text()),
+            )),
+            Line::from(""),
+            Line::from(vec![Span::styled(
+                "Typing Tips:",
+                Style::default().fg(Colors::title()).bold(),
+            )]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "• Focus on accuracy over speed initially",
+                Style::default().fg(Colors::text()),
+            )),
+            Line::from(Span::styled(
+                "• Use proper finger positioning",
+                Style::default().fg(Colors::text()),
+            )),
+            Line::from(Span::styled(
+                "• Practice regularly to improve muscle memory",
+                Style::default().fg(Colors::text()),
+            )),
+            Line::from(Span::styled(
+                "• Don't look at the keyboard while typing",
+                Style::default().fg(Colors::text()),
+            )),
+            Line::from(Span::styled(
+                "• Take breaks to avoid fatigue",
                 Style::default().fg(Colors::text()),
             )),
             Line::from(""),


### PR DESCRIPTION
## Summary
- Move Code Challenge Types section above Typing Tips in the Game Help screen
- Improve content flow and user experience by showing what types of challenges are available before giving typing advice

## Changes
- Reordered sections in `get_game_help_content()` function in `help_screen.rs`
- Code Challenge Types now appears immediately after Game Modes
- Typing Tips section moved below Code Challenge Types
- All section content remains unchanged

## Test plan
- [x] Run cargo clippy (no issues)
- [x] Run cargo fmt (formatting applied)
- [ ] Test help screen navigation in game
- [ ] Verify section ordering displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)