### PR TITLE
fix: prevent panic when selecting difficulty with no challenges

### DIFF
--- a/src/presentation/game/views/title/difficulty_selection_view.rs
+++ b/src/presentation/game/views/title/difficulty_selection_view.rs
@@ -18,6 +18,7 @@ impl DifficultySelectionView {
         difficulties: &[(&str, DifficultyLevel); 5],
         selected_difficulty: usize,
         challenge_counts: &[usize; 5],
+        error_message: Option<&String>,
     ) -> Result<()> {
         let start_row = center_row + 1;
         let (name, difficulty_level) = &difficulties[selected_difficulty];
@@ -75,18 +76,31 @@ impl DifficultySelectionView {
         execute!(stdout, Print(count_text))?;
         execute!(stdout, ResetColor)?;
 
-        // Line 3 & 4: Description lines
-        let descriptions = [difficulty_level.description(), difficulty_level.subtitle()];
-        for (i, description) in descriptions.iter().enumerate() {
-            let desc_col = center_col.saturating_sub(description.chars().count() as u16 / 2);
-            execute!(stdout, MoveTo(desc_col, start_row + 2 + i as u16))?;
+        // Line 3 & 4: Description lines or error message
+        if let Some(error) = error_message {
+            // Display error message in red
+            let error_col = center_col.saturating_sub(error.chars().count() as u16 / 2);
+            execute!(stdout, MoveTo(error_col, start_row + 2))?;
             execute!(
                 stdout,
-                SetForegroundColor(Colors::to_crossterm(Colors::text())),
-                SetAttribute(Attribute::Dim)
+                SetForegroundColor(Colors::to_crossterm(Colors::error())),
+                SetAttribute(Attribute::Bold)
             )?;
-            execute!(stdout, Print(description))?;
+            execute!(stdout, Print(error))?;
             execute!(stdout, ResetColor)?;
+        } else {
+            let descriptions = [difficulty_level.description(), difficulty_level.subtitle()];
+            for (i, description) in descriptions.iter().enumerate() {
+                let desc_col = center_col.saturating_sub(description.chars().count() as u16 / 2);
+                execute!(stdout, MoveTo(desc_col, start_row + 2 + i as u16))?;
+                execute!(
+                    stdout,
+                    SetForegroundColor(Colors::to_crossterm(Colors::text())),
+                    SetAttribute(Attribute::Dim)
+                )?;
+                execute!(stdout, Print(description))?;
+                execute!(stdout, ResetColor)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Closes: #276

## Summary
Fix panic that occurs when selecting difficulty on the title screen when repository contains no extractable challenges.

## Changes
- Add validation to check if challenges are available for selected difficulty before transitioning to Typing screen
- Display error message in red when no challenges are available for the selected difficulty
- Clear error message when user changes difficulty selection
- Prevent screen transition when challenge count is 0

## Test plan
- [x] Run `cargo check`
- [x] Run `cargo test`
- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Run `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Validates challenge availability before starting from the Title screen; shows a clear, centered error message if none.
  * Error message clears automatically when changing difficulty or selecting a valid option; normal descriptions return when no error is present.
* Bug Fixes
  * Prevents starting a session when the selected difficulty has zero available challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->