### PR TITLE
fix: show correct stage number on stage summary for first session

### DIFF
--- a/src/domain/models/loading/finalizing_step.rs
+++ b/src/domain/models/loading/finalizing_step.rs
@@ -1,12 +1,11 @@
 use super::{ExecutionContext, Step, StepResult, StepType};
-use crate::domain::models::{DifficultyLevel, SessionConfig, SessionState};
+use crate::domain::models::{DifficultyLevel, SessionConfig};
 use crate::domain::services::stage_builder_service::StageRepository;
 use crate::domain::services::SessionManager;
 use crate::infrastructure::git::LocalGitRepositoryClient;
 use crate::presentation::ui::Colors;
 use crate::{GitTypeError, Result};
 use ratatui::style::Color;
-use std::time::Instant;
 
 #[derive(Debug, Clone)]
 pub struct FinalizingStep;
@@ -114,12 +113,6 @@ impl Step for FinalizingStep {
 
                 // Set git repository context
                 concrete_session_manager.set_git_repository(git_repository);
-
-                // Start session by setting state to InProgress
-                concrete_session_manager.set_state(SessionState::InProgress {
-                    current_stage: 0,
-                    started_at: Instant::now(),
-                });
             }
         } else {
             log::warn!("SessionManager not available in context, skipping session initialization");

--- a/tests/unit/domain/services/session_manager_service_tests.rs
+++ b/tests/unit/domain/services/session_manager_service_tests.rs
@@ -418,6 +418,45 @@ fn test_get_stage_info_completed() {
     assert_eq!(total, 3);
 }
 
+// Regression: ensure the StageSummary screen displays the correct stage
+// number after each completion in a fresh session initialized via reset()
+// (the path used by FinalizingStep).
+#[test]
+fn test_stage_number_progression_after_reset() {
+    let manager = create_session_manager();
+    manager.reset();
+    manager.reduce(SessionAction::Start).unwrap();
+
+    // After Start, stage info reports the upcoming stage (1 of 3).
+    let (current, _) = manager.get_stage_info().unwrap();
+    assert_eq!(current, 1);
+    assert!(!manager.is_session_completed().unwrap());
+
+    // Stage 1 complete -> next stage is 2, displayed stage is 1.
+    manager
+        .reduce(SessionAction::CompleteStage(create_dummy_stage_result()))
+        .unwrap();
+    let (current, _) = manager.get_stage_info().unwrap();
+    assert_eq!(current, 2);
+    assert!(!manager.is_session_completed().unwrap());
+
+    // Stage 2 complete -> next stage is 3, displayed stage is 2.
+    manager
+        .reduce(SessionAction::CompleteStage(create_dummy_stage_result()))
+        .unwrap();
+    let (current, _) = manager.get_stage_info().unwrap();
+    assert_eq!(current, 3);
+    assert!(!manager.is_session_completed().unwrap());
+
+    // Stage 3 complete -> session completed, displayed stage is 3.
+    manager
+        .reduce(SessionAction::CompleteStage(create_dummy_stage_result()))
+        .unwrap();
+    let (current, _) = manager.get_stage_info().unwrap();
+    assert_eq!(current, 3);
+    assert!(manager.is_session_completed().unwrap());
+}
+
 // ============================================
 // Session duration
 // ============================================


### PR DESCRIPTION
## Summary
- `FinalizingStep` が state machine をバイパスして `set_state(InProgress { current_stage: 0 })` を呼んでおり、`handle_start_game_transition` の `is_in_progress()` チェックで `SessionAction::Start` がスキップされていた
- 結果、初回セッションの `current_stage` が 1 ずれ、Stage 2 完了時の StageSummary が "STAGE 1 COMPLETE" と表示されていた (#385)
- 明示的な `set_state` を削除して state machine に初期化を任せることで、`reduce(Start)` が正しく走り `current_stage=1` と `best_records_at_start` のキャプチャが両方行われるようになった

## Test plan
- [x] `cargo test --test mod` — 1939 passed / 0 failed
- [x] `cargo clippy --all-targets` — warning なし
- [x] `cargo fmt --check` — OK
- [x] リグレッションテスト `test_stage_number_progression_after_reset` を追加
- [ ] 実機確認: 起動直後のセッションで Stage 1/2/3 いずれも正しい番号が表示されること

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for session stage progression and completion state, verifying stages advance correctly and completion status is properly tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->