### PR TITLE
docs: restyle README hero section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://crates.io/crates/gittype"><img src="https://img.shields.io/crates/v/gittype.svg?style=flat-square&color=E06B4B" alt="crates.io"></a>
   <a href="https://github.com/unhappychoice/gittype/releases"><img src="https://img.shields.io/github/v/release/unhappychoice/gittype?style=flat-square&color=E0C14B&label=release" alt="release"></a>
   <a href="https://github.com/unhappychoice/gittype/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/unhappychoice/gittype/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://codecov.io/gh/unhappychoice/gittype"><img src="https://img.shields.io/codecov/c/github/unhappychoice/gittype?style=flat-square" alt="codecov"></a>
   <a href="https://github.com/unhappychoice/gittype/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gittype.svg?style=flat-square" alt="license"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-![GitType Banner](docs/images/gittype-banner.png)
+<p align="center">
+  <img src="docs/images/gittype-banner.png" alt="GitType" width="820">
+</p>
 
-# GitType ⌨️💻
+<p align="center">
+  <a href="https://crates.io/crates/gittype"><img src="https://img.shields.io/crates/v/gittype.svg?style=flat-square&color=E06B4B" alt="crates.io"></a>
+  <a href="https://github.com/unhappychoice/gittype/releases"><img src="https://img.shields.io/github/v/release/unhappychoice/gittype?style=flat-square&color=E0C14B&label=release" alt="release"></a>
+  <a href="https://github.com/unhappychoice/gittype/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/unhappychoice/gittype/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://github.com/unhappychoice/gittype/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gittype.svg?style=flat-square" alt="license"></a>
+</p>
 
-> *"Show your AI who's boss: just you, your keyboard, and your coding sins"*
+<p align="center">
+  <strong>Turn your own source code into typing challenges.</strong><br>
+  <sub>Show your AI who's boss — just you, your keyboard, and your coding sins.</sub>
+</p>
 
-**GitType** turns your own source code into typing challenges. Because why practice with boring lorem ipsum when you can type your beautiful `fn main()` implementations?
-
-## Demo 🎬
-
-![GitType Demo](docs/images/demo.gif)
+<p align="center">
+  <img src="docs/images/demo.gif" alt="GitType Demo" width="820">
+</p>
 
 ## Features ✨
 


### PR DESCRIPTION
## Summary
- Restyle the README hero section to match `../gitlogue`: centered image + badge row + tagline
- Add crates.io / release / CI / license badges
- Drop the standalone `## Demo 🎬` section and inline `demo.gif` directly under the hero

## Test plan
- [ ] Verify README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned project README with a centered hero area: banner image, repository badges and tagline for a stronger first impression.
  * Included a large centered demo image within the new layout.
  * Updated header layout that supersedes the previous Demo section header while leaving remaining content (Features, Installation, Quick Start) unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->