### PR TITLE
test: improve coverage in iterative loop

### DIFF
--- a/src/domain/services/session_manager_service.rs
+++ b/src/domain/services/session_manager_service.rs
@@ -304,6 +304,16 @@ impl SessionManager {
         *self.git_repository.lock().unwrap() = git_repository;
     }
 
+    #[cfg(feature = "test-mocks")]
+    pub fn get_session_challenges_for_test(&self) -> Vec<Challenge> {
+        self.session_challenges.lock().unwrap().clone()
+    }
+
+    #[cfg(feature = "test-mocks")]
+    pub fn get_stage_trackers_for_test(&self) -> Vec<(String, StageTracker)> {
+        self.stage_trackers.lock().unwrap().clone()
+    }
+
     /// Add stage data (tracker and challenge) for the current stage
     pub fn add_stage_data(
         &self,

--- a/src/presentation/tui/screens/loading_screen.rs
+++ b/src/presentation/tui/screens/loading_screen.rs
@@ -178,6 +178,22 @@ impl LoadingScreen {
             session_manager,
         }
     }
+
+    #[cfg(feature = "test-mocks")]
+    pub fn session_store_for_test(&self) -> Arc<dyn SessionStoreInterface> {
+        self.session_store.clone()
+    }
+
+    #[cfg(feature = "test-mocks")]
+    pub fn current_step_for_test(&self) -> StepType {
+        self.state
+            .read()
+            .unwrap()
+            .current_step
+            .read()
+            .unwrap()
+            .clone()
+    }
 }
 
 #[derive(Clone)]

--- a/src/presentation/tui/screens/total_summary_screen.rs
+++ b/src/presentation/tui/screens/total_summary_screen.rs
@@ -24,6 +24,15 @@ pub struct TotalSummaryScreenDataProvider {
     total_tracker: Arc<Mutex<Option<TotalTracker>>>,
 }
 
+impl TotalSummaryScreenDataProvider {
+    #[cfg(feature = "test-mocks")]
+    pub fn new_for_test(tracker: Option<TotalTracker>) -> Self {
+        Self {
+            total_tracker: Arc::new(Mutex::new(tracker)),
+        }
+    }
+}
+
 impl ScreenDataProvider for TotalSummaryScreenDataProvider {
     fn provide(&self) -> Result<Box<dyn std::any::Any>> {
         let total_result = self

--- a/src/presentation/tui/screens/total_summary_share_screen.rs
+++ b/src/presentation/tui/screens/total_summary_share_screen.rs
@@ -20,6 +20,15 @@ pub struct TotalSummaryShareDataProvider {
     total_tracker: Arc<Mutex<Option<TotalTracker>>>,
 }
 
+impl TotalSummaryShareDataProvider {
+    #[cfg(feature = "test-mocks")]
+    pub fn new_for_test(tracker: Option<TotalTracker>) -> Self {
+        Self {
+            total_tracker: Arc::new(Mutex::new(tracker)),
+        }
+    }
+}
+
 impl ScreenDataProvider for TotalSummaryShareDataProvider {
     fn provide(&self) -> Result<Box<dyn std::any::Any>> {
         let total_result = self

--- a/tests/integration/screens/analytics_screen_test.rs
+++ b/tests/integration/screens/analytics_screen_test.rs
@@ -324,3 +324,103 @@ screen_basic_methods_test!(
     false,
     MockAnalyticsDataProvider
 );
+
+fn build_analytics_screen() -> AnalyticsScreen {
+    let event_bus = Arc::new(EventBus::new());
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    AnalyticsScreen::new(event_bus, theme_service)
+}
+
+fn send_keys(screen: &AnalyticsScreen, keys: &[KeyCode]) {
+    for code in keys {
+        screen
+            .handle_key_event(KeyEvent::new(*code, KeyModifiers::empty()))
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_analytics_screen_down_navigates_repository_list() {
+    let screen = build_analytics_screen();
+    screen
+        .init_with_data(MockAnalyticsDataProvider.provide().unwrap())
+        .unwrap();
+
+    send_keys(
+        &screen,
+        &[KeyCode::Right, KeyCode::Right, KeyCode::Down, KeyCode::Down],
+    );
+
+    // Re-renders without panicking after wrapping
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut terminal = ratatui::Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            screen.render_ratatui(f).unwrap();
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_analytics_screen_up_navigates_repository_list() {
+    let screen = build_analytics_screen();
+    screen
+        .init_with_data(MockAnalyticsDataProvider.provide().unwrap())
+        .unwrap();
+
+    // Right, Right to Repositories, then Up wraps from 0 to last, then Up again to 0.
+    send_keys(
+        &screen,
+        &[KeyCode::Right, KeyCode::Right, KeyCode::Up, KeyCode::Up],
+    );
+}
+
+#[test]
+fn test_analytics_screen_navigates_language_list_with_jk() {
+    let screen = build_analytics_screen();
+    screen
+        .init_with_data(MockAnalyticsDataProvider.provide().unwrap())
+        .unwrap();
+
+    // Right Right Right to Languages, then j j k k for next/previous wrapping paths.
+    send_keys(
+        &screen,
+        &[
+            KeyCode::Right,
+            KeyCode::Right,
+            KeyCode::Right,
+            KeyCode::Char('j'),
+            KeyCode::Char('j'),
+            KeyCode::Char('k'),
+            KeyCode::Char('k'),
+        ],
+    );
+}
+
+#[test]
+fn test_analytics_screen_unhandled_key_returns_ok() {
+    let screen = build_analytics_screen();
+    screen
+        .init_with_data(MockAnalyticsDataProvider.provide().unwrap())
+        .unwrap();
+
+    let result = screen.handle_key_event(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::empty()));
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_analytics_view_mode_default_is_overview() {
+    assert_eq!(ViewMode::default(), ViewMode::Overview);
+}
+
+#[test]
+fn test_analytics_view_mode_display_names() {
+    assert_eq!(ViewMode::Overview.display_name(), "Overview");
+    assert_eq!(ViewMode::Trends.display_name(), "Trends");
+    assert_eq!(ViewMode::Repositories.display_name(), "Repositories");
+    assert_eq!(ViewMode::Languages.display_name(), "Languages");
+}

--- a/tests/integration/screens/analytics_screen_test.rs
+++ b/tests/integration/screens/analytics_screen_test.rs
@@ -401,6 +401,49 @@ fn test_analytics_screen_navigates_language_list_with_jk() {
 }
 
 #[test]
+fn test_analytics_screen_renders_language_without_detailed_stats() {
+    // MockAnalyticsDataProvider's top_languages contains both "Rust" and "Python",
+    // but language_stats only has an entry for "Rust" — navigating to Python triggers
+    // the `else` branch in LanguagesView::render_language_details where `detailed_stats`
+    // resolves to None.
+    let screen = build_analytics_screen();
+    screen
+        .init_with_data(MockAnalyticsDataProvider.provide().unwrap())
+        .unwrap();
+
+    send_keys(
+        &screen,
+        &[
+            KeyCode::Right,
+            KeyCode::Right,
+            KeyCode::Right,
+            KeyCode::Char('j'),
+        ],
+    );
+
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut terminal = ratatui::Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            screen.render_ratatui(f).unwrap();
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let mut output = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            output.push_str(buffer[(x, y)].symbol());
+        }
+        output.push('\n');
+    }
+
+    assert!(output.contains("Python"));
+    assert!(output.contains("Session Count"));
+    assert!(output.contains("WPM Equivalent"));
+}
+
+#[test]
 fn test_analytics_screen_unhandled_key_returns_ok() {
     let screen = build_analytics_screen();
     screen

--- a/tests/integration/screens/animation_screen_test.rs
+++ b/tests/integration/screens/animation_screen_test.rs
@@ -1,5 +1,5 @@
 use crate::integration::screens::mocks::animation_screen_mock::MockAnimationDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
@@ -15,8 +15,13 @@ use gittype::domain::stores::{ChallengeStore, RepositoryStore, SessionStore};
 use gittype::domain::stores::{
     ChallengeStoreInterface, RepositoryStoreInterface, SessionStoreInterface,
 };
-use gittype::presentation::tui::screens::animation_screen::AnimationScreen;
-use std::sync::Arc;
+use gittype::presentation::tui::screens::animation_screen::{
+    AnimationDataProvider, AnimationScreen,
+};
+use gittype::presentation::tui::{Screen, ScreenDataProvider, ScreenType, UpdateStrategy};
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use std::sync::{Arc, Mutex};
 
 // Helper function to create AnimationScreen with all required dependencies
 fn create_animation_screen(event_bus: Arc<dyn EventBusInterface>) -> AnimationScreen {
@@ -94,3 +99,148 @@ screen_basic_methods_test!(
     false,
     MockAnimationDataProvider
 );
+
+// A SessionManagerInterface impl that is not SessionManager, so the screen's
+// downcast_ref::<SessionManager>() in init_with_data() fails.
+struct FakeSessionManager;
+
+impl SessionManagerInterface for FakeSessionManager {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn create_animation_screen_with_fake_session_manager(
+    event_bus: Arc<dyn EventBusInterface>,
+) -> AnimationScreen {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let session_manager = Arc::new(FakeSessionManager) as Arc<dyn SessionManagerInterface>;
+    AnimationScreen::new(event_bus, theme_service, session_manager)
+}
+
+#[test]
+fn animation_data_provider_provides_unit_value() {
+    let provider = AnimationDataProvider;
+    let any_data = provider.provide().unwrap();
+    assert!(any_data.downcast::<()>().is_ok());
+}
+
+#[test]
+fn init_with_data_falls_back_to_session_manager_when_data_is_unit() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen(event_bus);
+
+    let result = screen.init_with_data(Box::new(()));
+
+    assert!(result.is_ok());
+    // After fallback through SessionManager, animation should be initialized.
+    assert!(!screen.is_animation_complete());
+}
+
+#[test]
+fn init_with_data_returns_err_when_session_manager_is_not_real_session_manager() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen_with_fake_session_manager(event_bus);
+
+    let result = screen.init_with_data(Box::new(()));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn is_animation_complete_returns_false_when_animation_not_set() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen(event_bus);
+
+    assert!(!screen.is_animation_complete());
+}
+
+#[test]
+fn update_returns_false_when_no_animation_set() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen(event_bus);
+
+    let updated = screen.update().unwrap();
+    assert!(!updated);
+}
+
+#[test]
+fn handle_key_event_unrelated_key_publishes_no_event() {
+    let event_bus = Arc::new(EventBus::new());
+    let events: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = Arc::clone(&events);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        events_clone.lock().unwrap().push(event.clone());
+    });
+
+    let screen = create_animation_screen(event_bus);
+    let data = MockAnimationDataProvider.provide().unwrap();
+    screen.init_with_data(data).unwrap();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn handle_key_event_plain_c_without_ctrl_publishes_no_event() {
+    let event_bus = Arc::new(EventBus::new());
+    let events: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = Arc::clone(&events);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        events_clone.lock().unwrap().push(event.clone());
+    });
+
+    let screen = create_animation_screen(event_bus);
+    let data = MockAnimationDataProvider.provide().unwrap();
+    screen.init_with_data(data).unwrap();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn render_ratatui_succeeds_without_initialization() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen(event_bus);
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+}
+
+#[test]
+fn get_type_returns_animation_screen_type() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen(event_bus);
+    assert_eq!(screen.get_type(), ScreenType::Animation);
+}
+
+#[test]
+fn get_update_strategy_is_time_based() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_animation_screen(event_bus);
+    assert!(matches!(
+        screen.get_update_strategy(),
+        UpdateStrategy::TimeBased(_)
+    ));
+}
+
+#[test]
+fn default_provider_returns_animation_data_provider() {
+    let provider = <AnimationScreen as Screen>::default_provider();
+    let any_data = provider.provide().unwrap();
+    assert!(any_data.downcast::<()>().is_ok());
+}

--- a/tests/integration/screens/help_screen_test.rs
+++ b/tests/integration/screens/help_screen_test.rs
@@ -171,3 +171,187 @@ screen_basic_methods_test!(
     gittype::presentation::tui::ScreenType::Help,
     false
 );
+
+use gittype::presentation::tui::screens::help_screen::HelpSection;
+use gittype::presentation::tui::Screen;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+fn make_help_screen() -> HelpScreen {
+    HelpScreen::new(
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+    )
+}
+
+fn render_buffer_text(screen: &HelpScreen) -> String {
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let mut output = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            output.push_str(buffer[(x, y)].symbol());
+        }
+        output.push('\n');
+    }
+    output
+}
+
+fn press(screen: &HelpScreen, code: KeyCode) {
+    screen
+        .handle_key_event(KeyEvent::new(code, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn help_section_title_covers_all_variants() {
+    assert_eq!(HelpSection::Scoring.title(), "Scoring System");
+    assert_eq!(HelpSection::Ranks.title(), "Rank System");
+    assert_eq!(HelpSection::GameHelp.title(), "Game Help");
+    assert_eq!(HelpSection::CLI.title(), "CLI Usage");
+    assert_eq!(HelpSection::About.title(), "About & Credits");
+    assert_eq!(
+        HelpSection::ThirdPartyLicenses.title(),
+        "Third-Party Licenses"
+    );
+    assert_eq!(HelpSection::Community.title(), "Community");
+}
+
+#[test]
+fn help_section_all_lists_every_variant_in_order() {
+    let sections = HelpSection::all();
+    assert_eq!(
+        sections,
+        vec![
+            HelpSection::CLI,
+            HelpSection::Scoring,
+            HelpSection::Ranks,
+            HelpSection::GameHelp,
+            HelpSection::Community,
+            HelpSection::About,
+            HelpSection::ThirdPartyLicenses,
+        ]
+    );
+}
+
+#[test]
+fn help_section_default_is_cli() {
+    assert_eq!(HelpSection::default(), HelpSection::CLI);
+}
+
+#[test]
+fn rendering_about_section_includes_credits_content() {
+    let screen = make_help_screen();
+    // CLI -> Scoring -> Ranks -> GameHelp -> Community -> About
+    for _ in 0..5 {
+        press(&screen, KeyCode::Right);
+    }
+    let output = render_buffer_text(&screen);
+
+    assert!(output.contains("GitType"));
+    assert!(output.contains("unhappychoice"));
+    assert!(output.contains("Development Team"));
+}
+
+#[test]
+fn rendering_third_party_licenses_section_includes_license_content() {
+    let screen = make_help_screen();
+    for _ in 0..6 {
+        press(&screen, KeyCode::Right);
+    }
+    let output = render_buffer_text(&screen);
+
+    // THIRD_PARTY_LICENSES is included from a real LICENSE file; just confirm
+    // get_third_party_licenses_content rendered something rather than empty content.
+    let trimmed: String = output.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(!trimmed.is_empty());
+    assert!(output.contains("Third-Party Licenses"));
+}
+
+#[test]
+fn pressing_left_from_cli_wraps_to_last_section() {
+    let screen = make_help_screen();
+    press(&screen, KeyCode::Left);
+    let output = render_buffer_text(&screen);
+
+    // After wrap, current section is ThirdPartyLicenses (the last entry).
+    assert!(output.contains("Third-Party Licenses"));
+}
+
+#[test]
+fn pressing_h_wraps_to_last_section_like_left() {
+    let screen = make_help_screen();
+    press(&screen, KeyCode::Char('h'));
+    let output = render_buffer_text(&screen);
+
+    assert!(output.contains("Third-Party Licenses"));
+}
+
+#[test]
+fn pressing_down_then_up_keeps_scroll_position_within_bounds() {
+    let screen = make_help_screen();
+    // Move to ThirdPartyLicenses which has long content so max_scroll > 0.
+    for _ in 0..6 {
+        press(&screen, KeyCode::Right);
+    }
+    // Render once so render_content publishes content_height/viewport_height.
+    let _ = render_buffer_text(&screen);
+
+    // Scrolling down with content larger than viewport should be a no-panic op
+    // and must not error.
+    for _ in 0..10 {
+        press(&screen, KeyCode::Down);
+    }
+    for _ in 0..3 {
+        press(&screen, KeyCode::Char('j'));
+    }
+
+    // Scrolling back up should also be safe (saturating_sub).
+    for _ in 0..30 {
+        press(&screen, KeyCode::Up);
+    }
+    for _ in 0..3 {
+        press(&screen, KeyCode::Char('k'));
+    }
+
+    let _ = render_buffer_text(&screen);
+}
+
+#[test]
+fn pressing_up_at_top_of_cli_is_a_noop() {
+    let screen = make_help_screen();
+    // CLI content fits in the viewport so scroll stays clamped at 0.
+    press(&screen, KeyCode::Up);
+    press(&screen, KeyCode::Char('k'));
+    let _ = render_buffer_text(&screen);
+}
+
+#[test]
+fn unhandled_key_in_main_view_is_a_noop() {
+    let screen = make_help_screen();
+    // Tab is not bound; should hit the `_ => Ok(())` arm.
+    press(&screen, KeyCode::Tab);
+}
+
+#[test]
+fn help_screen_as_any_downcasts_back_to_concrete_type() {
+    let screen = make_help_screen();
+    assert!(screen.as_any().downcast_ref::<HelpScreen>().is_some());
+}
+
+#[test]
+fn help_screen_default_provider_returns_unit() {
+    let provider = HelpScreen::default_provider();
+    let boxed = provider.provide().unwrap();
+    assert!(boxed.downcast_ref::<()>().is_some());
+}

--- a/tests/integration/screens/loading_screen_test.rs
+++ b/tests/integration/screens/loading_screen_test.rs
@@ -421,3 +421,58 @@ fn test_render_ratatui_finalizing_step() {
         })
         .unwrap();
 }
+
+#[test]
+fn test_update_returns_false_and_completes_when_loading_completed() {
+    let screen = create_loading_screen();
+    screen.session_store_for_test().set_loading_completed(true);
+
+    let updated = screen.update().unwrap();
+
+    assert!(!updated);
+    assert_eq!(screen.current_step_for_test(), StepType::Completed);
+}
+
+#[test]
+fn test_update_returns_false_when_loading_failed() {
+    let screen = create_loading_screen();
+    screen.session_store_for_test().set_loading_failed(true);
+
+    let updated = screen.update().unwrap();
+
+    assert!(!updated);
+}
+
+#[test]
+fn test_screen_cleanup_via_trait_returns_ok() {
+    let screen: Box<dyn Screen> = Box::new(create_loading_screen());
+    assert!(screen.cleanup().is_ok());
+}
+
+#[test]
+fn test_as_any_downcasts_to_concrete_type() {
+    let screen = create_loading_screen();
+    assert!(screen.as_any().downcast_ref::<LoadingScreen>().is_some());
+}
+
+#[test]
+fn test_show_completion_without_cleanup_sets_completed_step() {
+    let screen = create_loading_screen();
+    screen.show_completion_without_cleanup().unwrap();
+    assert_eq!(screen.current_step_for_test(), StepType::Completed);
+}
+
+#[test]
+fn test_show_completion_sets_completed_step_and_returns_ok() {
+    let screen = create_loading_screen();
+    screen.show_completion().unwrap();
+    assert_eq!(screen.current_step_for_test(), StepType::Completed);
+}
+
+#[test]
+fn test_init_with_data_returns_ok_with_default_provider() {
+    let screen = create_loading_screen();
+    let data = LoadingScreen::default_provider().provide().unwrap();
+    assert!(screen.init_with_data(data).is_ok());
+    let _ = screen.cleanup();
+}

--- a/tests/integration/screens/panic_screen_test.rs
+++ b/tests/integration/screens/panic_screen_test.rs
@@ -92,3 +92,71 @@ screen_basic_methods_test!(
     gittype::presentation::tui::ScreenType::Panic,
     false
 );
+
+screen_snapshot_test!(
+    test_panic_screen_snapshot_with_location_line,
+    PanicScreen,
+    PanicScreen::with_error_message(
+        "boom!\nLocation: src/foo.rs:42:10\ntrailing".to_string(),
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark
+        )) as Arc<dyn ThemeServiceInterface>,
+        Some("SystemTime { tv_sec: 1700000000, tv_nsec: 0 }".to_string())
+    )
+);
+
+#[test]
+fn test_panic_screen_as_any_downcasts_to_concrete_type() {
+    use gittype::presentation::tui::Screen;
+
+    let screen = PanicScreen::new(
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+    );
+
+    assert!(screen.as_any().downcast_ref::<PanicScreen>().is_some());
+}
+
+#[test]
+fn test_panic_screen_provider_returns_panic_screen() {
+    use gittype::presentation::di::AppModule;
+    use gittype::presentation::tui::screens::panic_screen::PanicScreenProvider;
+    use shaku::Provider;
+
+    let module = AppModule::builder().build();
+    let provided = <PanicScreenProvider as Provider<AppModule>>::provide(&module);
+
+    assert!(provided.is_ok());
+}
+
+#[test]
+fn test_panic_screen_with_error_message_falls_back_to_current_timestamp() {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+
+    let screen = PanicScreen::with_error_message(
+        "no timestamp provided".to_string(),
+        Arc::new(EventBus::new()),
+        theme_service,
+        None,
+    );
+
+    use gittype::presentation::tui::Screen;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+}

--- a/tests/integration/screens/repo_play_screen_test.rs
+++ b/tests/integration/screens/repo_play_screen_test.rs
@@ -1,12 +1,13 @@
 use crate::integration::screens::mocks::repo_play_screen_mock::MockRepoPlayDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::domain::models::color_mode::ColorMode;
 use gittype::domain::models::theme::Theme;
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
 use gittype::presentation::tui::screens::RepoPlayScreen;
-use std::sync::Arc;
+use gittype::presentation::tui::{Screen, ScreenDataProvider};
+use std::sync::{Arc, Mutex};
 
 screen_snapshot_test!(
     test_repo_play_screen_snapshot,
@@ -92,3 +93,159 @@ screen_basic_methods_test!(
     true,
     MockRepoPlayDataProvider
 );
+
+fn make_screen() -> RepoPlayScreen {
+    RepoPlayScreen::new(
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+    )
+}
+
+#[test]
+fn test_repo_play_screen_selected_accessors_default_to_none() {
+    let screen = make_screen();
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    assert!(screen.get_selected_index().is_none());
+    assert!(screen.get_selected_repository().is_none());
+}
+
+#[test]
+fn test_repo_play_screen_space_sets_selected_repository_for_caller() {
+    let screen = make_screen();
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(0));
+    let (repo, cached) = screen
+        .get_selected_repository()
+        .expect("space should record a selection");
+    assert_eq!(repo.user_name, "unhappychoice");
+    assert!(!cached);
+}
+
+#[test]
+fn test_repo_play_screen_down_then_space_selects_second_repository() {
+    let screen = make_screen();
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    let (repo, cached) = screen
+        .get_selected_repository()
+        .expect("down + space should record a selection");
+    assert_eq!(repo.user_name, "rails");
+    assert!(cached);
+}
+
+#[test]
+fn test_repo_play_screen_up_at_first_index_stays_at_zero() {
+    let screen = make_screen();
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(0));
+}
+
+#[test]
+fn test_repo_play_screen_down_past_end_clamps_to_last_index() {
+    let screen = make_screen();
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    for _ in 0..10 {
+        screen
+            .handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()))
+            .unwrap();
+    }
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(2));
+}
+
+#[test]
+fn test_repo_play_screen_key_release_event_is_ignored() {
+    let screen = make_screen();
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    let release_event = KeyEvent {
+        code: KeyCode::Char(' '),
+        modifiers: KeyModifiers::empty(),
+        kind: KeyEventKind::Release,
+        state: KeyEventState::empty(),
+    };
+
+    screen.handle_key_event(release_event).unwrap();
+
+    assert!(screen.get_selected_index().is_none());
+}
+
+#[test]
+fn test_repo_play_screen_unhandled_key_does_not_publish_or_select() {
+    let event_bus = Arc::new(EventBus::new());
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let captured = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let captured_clone = Arc::clone(&captured);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        captured_clone.lock().unwrap().push(event.clone());
+    });
+
+    let screen = RepoPlayScreen::new(event_bus, theme_service);
+    screen
+        .init_with_data(MockRepoPlayDataProvider.provide().unwrap())
+        .unwrap();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(captured.lock().unwrap().is_empty());
+    assert!(screen.get_selected_index().is_none());
+}
+
+#[test]
+fn test_repo_play_screen_cleanup_returns_ok() {
+    let screen = make_screen();
+
+    assert!(screen.cleanup().is_ok());
+}
+
+#[test]
+fn test_repo_play_screen_as_any_downcasts_to_concrete_type() {
+    let screen = make_screen();
+
+    assert!(screen.as_any().downcast_ref::<RepoPlayScreen>().is_some());
+}

--- a/tests/integration/screens/session_detail_screen_test.rs
+++ b/tests/integration/screens/session_detail_screen_test.rs
@@ -1,16 +1,22 @@
 use crate::integration::screens::mocks::records_screen_mock::MockRecordsDataProvider;
 use crate::integration::screens::mocks::session_repository_mock::MockSessionRepository;
 use crate::integration::screens::mocks::session_service_mock::MockSessionService;
+use chrono::{TimeZone, Utc};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
+use gittype::domain::models::storage::{SessionResultData, StoredSession};
 use gittype::domain::models::theme::Theme;
+use gittype::domain::services::session_service::SessionDisplayData;
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
+use gittype::presentation::tui::screens::records_screen::RecordsScreenData;
 use gittype::presentation::tui::screens::{RecordsScreen, SessionDetailScreen};
-use gittype::presentation::tui::Screen;
 use gittype::presentation::tui::ScreenDataProvider;
+use gittype::presentation::tui::{Screen, ScreenType, UpdateStrategy};
 use gittype::GitTypeError;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
 use std::sync::{Arc, Mutex};
 
 // Helper function to create and initialize SessionDetailScreen from RecordsScreen
@@ -153,4 +159,211 @@ fn test_session_detail_screen_down_scrolls() {
     screen
         .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
         .unwrap();
+}
+
+fn build_records_screen_with(sessions: Vec<SessionDisplayData>) -> RecordsScreen {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let records = RecordsScreen::new(
+        Arc::new(EventBus::new()),
+        theme_service,
+        Arc::new(MockSessionService::new()),
+    );
+    let data: Box<dyn std::any::Any> = Box::new(RecordsScreenData {
+        sessions,
+        repositories: Vec::new(),
+    });
+    records.init_with_data(data).unwrap();
+    records
+}
+
+fn session_with_id(id: i64) -> SessionDisplayData {
+    SessionDisplayData {
+        session: StoredSession {
+            id,
+            repository_id: None,
+            started_at: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+            completed_at: None,
+            branch: None,
+            commit_hash: None,
+            is_dirty: false,
+            game_mode: "default".to_string(),
+            difficulty_level: None,
+            max_stages: Some(1),
+            time_limit_seconds: None,
+        },
+        repository: None,
+        session_result: Some(SessionResultData {
+            keystrokes: 0,
+            mistakes: 0,
+            duration_ms: 0,
+            wpm: 0.0,
+            cpm: 0.0,
+            accuracy: 0.0,
+            stages_completed: 0,
+            stages_attempted: 0,
+            stages_skipped: 0,
+            score: 0.0,
+            rank_name: None,
+            tier_name: None,
+            rank_position: None,
+            rank_total: None,
+            position: None,
+            total: None,
+        }),
+    }
+}
+
+fn make_screen() -> SessionDetailScreen {
+    SessionDetailScreen::new(
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+        Arc::new(MockSessionRepository::new()),
+    )
+}
+
+#[test]
+fn test_session_detail_screen_rejects_records_without_selected_session() {
+    let screen = make_screen();
+    let records = build_records_screen_with(vec![session_with_id(1)]);
+    // No `set_selected_session_from_index` call → `get_selected_session_for_detail` returns None.
+
+    let result = screen.on_pushed_from(&records);
+
+    assert!(matches!(
+        result,
+        Err(GitTypeError::ScreenInitializationError(message))
+            if message == "SessionDetail requires selected session data from Records screen"
+    ));
+}
+
+#[test]
+fn test_session_detail_screen_rejects_session_with_id_zero() {
+    let screen = make_screen();
+    let records = build_records_screen_with(vec![session_with_id(0)]);
+    records.set_selected_session_from_index(0);
+
+    let result = screen.on_pushed_from(&records);
+
+    assert!(matches!(
+        result,
+        Err(GitTypeError::ScreenInitializationError(message))
+            if message == "SessionDetail: session id cannot be 0"
+    ));
+}
+
+#[test]
+fn test_session_detail_screen_up_after_down_scrolls_back() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_initialized_session_detail_screen(event_bus);
+
+    // Scroll down to a non-zero offset, then back up to exercise both
+    // branches of the Up handler (the `*offset > 0` true branch in particular).
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_session_detail_screen_down_stops_at_last_stage() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_initialized_session_detail_screen(event_bus);
+
+    // Mock returns 3 stage results. Pressing Down four times forces the
+    // saturating no-op branch (`*offset + 1 < stage_results.len()` is false).
+    for _ in 0..4 {
+        screen
+            .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_session_detail_screen_ignores_unhandled_key() {
+    let event_bus = Arc::new(EventBus::new());
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = Arc::clone(&events);
+
+    event_bus.subscribe(move |event: &NavigateTo| {
+        events_clone.lock().unwrap().push(event.clone());
+    });
+
+    let screen = create_initialized_session_detail_screen(event_bus);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn test_session_detail_screen_init_with_data_accepts_any_payload() {
+    let screen = make_screen();
+    assert!(screen.init_with_data(Box::new(())).is_ok());
+    assert!(screen.init_with_data(Box::new(42i64)).is_ok());
+}
+
+#[test]
+fn test_session_detail_screen_basic_screen_methods() {
+    let screen = make_screen();
+
+    assert_eq!(screen.get_type(), ScreenType::SessionDetail);
+    assert!(matches!(
+        screen.get_update_strategy(),
+        UpdateStrategy::InputOnly
+    ));
+    assert!(!screen.update().unwrap());
+    assert!(screen.cleanup().is_ok());
+    assert!(screen
+        .as_any()
+        .downcast_ref::<SessionDetailScreen>()
+        .is_some());
+}
+
+#[test]
+fn test_session_detail_screen_render_after_scroll_keys() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_initialized_session_detail_screen(event_bus);
+
+    // Scroll the stage details panel a bit before rendering so the render
+    // path picks up a non-zero `stage_scroll_offset`.
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+        .unwrap();
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let mut rendered = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            rendered.push_str(buffer[(x, y)].symbol());
+        }
+        rendered.push('\n');
+    }
+    assert!(rendered.contains("Session Details"));
 }

--- a/tests/integration/screens/session_details_dialog_test.rs
+++ b/tests/integration/screens/session_details_dialog_test.rs
@@ -1,5 +1,5 @@
 use crate::integration::screens::mocks::session_details_dialog_mock::MockSessionDetailsDialogDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
@@ -16,7 +16,9 @@ use gittype::domain::stores::{
     ChallengeStoreInterface, RepositoryStoreInterface, SessionStoreInterface,
 };
 use gittype::presentation::tui::screens::session_details_dialog::SessionDetailsDialog;
-use std::sync::Arc;
+use gittype::presentation::tui::Screen;
+use gittype::GitTypeError;
+use std::sync::{Arc, Mutex};
 
 // Helper function to create SessionDetailsDialog with all required dependencies
 fn create_session_details_dialog(event_bus: Arc<dyn EventBusInterface>) -> SessionDetailsDialog {
@@ -84,3 +86,94 @@ screen_basic_methods_test!(
     false,
     MockSessionDetailsDialogDataProvider
 );
+
+#[derive(Debug)]
+struct NonConcreteSessionManager;
+
+impl SessionManagerInterface for NonConcreteSessionManager {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn create_session_details_dialog_with_session_manager(
+    event_bus: Arc<dyn EventBusInterface>,
+    session_manager: Arc<dyn SessionManagerInterface>,
+) -> SessionDetailsDialog {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let repository_store =
+        Arc::new(RepositoryStore::new_for_test()) as Arc<dyn RepositoryStoreInterface>;
+
+    SessionDetailsDialog::new(event_bus, theme_service, session_manager, repository_store)
+}
+
+#[test]
+fn test_session_details_dialog_init_without_data_uses_session_manager_fallback() {
+    let screen = create_session_details_dialog(Arc::new(EventBus::new()));
+
+    // Box<()> is not SessionDetailsDialogData, so the fallback branch runs.
+    screen.init_with_data(Box::new(())).unwrap();
+}
+
+#[test]
+fn test_session_details_dialog_init_without_data_rejects_non_concrete_session_manager() {
+    let screen = create_session_details_dialog_with_session_manager(
+        Arc::new(EventBus::new()),
+        Arc::new(NonConcreteSessionManager),
+    );
+
+    let error = screen.init_with_data(Box::new(())).unwrap_err();
+
+    assert!(matches!(
+        error,
+        GitTypeError::TerminalError(message)
+            if message == "Failed to get SessionManager"
+    ));
+}
+
+#[test]
+fn test_session_details_dialog_unhandled_key_does_not_publish_navigation() {
+    let event_bus = Arc::new(EventBus::new());
+    let published_events = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let observed_events = Arc::clone(&published_events);
+    let screen = create_session_details_dialog(event_bus.clone());
+
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed_events.lock().unwrap().push(event.clone());
+    });
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(published_events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn test_session_details_dialog_default_provider_returns_unit_data() {
+    let data = <SessionDetailsDialog as Screen>::default_provider()
+        .provide()
+        .unwrap();
+
+    assert!(data.downcast::<()>().is_ok());
+}
+
+#[test]
+fn test_session_details_dialog_as_any_downcasts_to_concrete_type() {
+    let screen = create_session_details_dialog(Arc::new(EventBus::new()));
+
+    assert!(screen
+        .as_any()
+        .downcast_ref::<SessionDetailsDialog>()
+        .is_some());
+}
+
+#[test]
+fn test_session_details_dialog_cleanup_is_ok() {
+    let screen = create_session_details_dialog(Arc::new(EventBus::new()));
+
+    assert!(screen.cleanup().is_ok());
+}

--- a/tests/integration/screens/session_failure_screen_test.rs
+++ b/tests/integration/screens/session_failure_screen_test.rs
@@ -1,5 +1,5 @@
 use crate::integration::screens::mocks::session_failure_screen_mock::MockSessionFailureDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
@@ -16,7 +16,9 @@ use gittype::domain::stores::{
     ChallengeStoreInterface, RepositoryStoreInterface, SessionStoreInterface,
 };
 use gittype::presentation::tui::screens::session_failure_screen::SessionFailureScreen;
-use std::sync::Arc;
+use gittype::presentation::tui::Screen;
+use gittype::GitTypeError;
+use std::sync::{Arc, Mutex};
 
 // Helper function to create SessionFailureScreen with all required dependencies
 fn create_session_failure_screen(event_bus: Arc<dyn EventBusInterface>) -> SessionFailureScreen {
@@ -124,3 +126,89 @@ screen_basic_methods_test!(
     false,
     MockSessionFailureDataProvider
 );
+
+#[derive(Debug)]
+struct NonConcreteSessionManager;
+
+impl SessionManagerInterface for NonConcreteSessionManager {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn create_session_failure_screen_with_session_manager(
+    event_bus: Arc<dyn EventBusInterface>,
+    session_manager: Arc<dyn SessionManagerInterface>,
+) -> SessionFailureScreen {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let repository_store =
+        Arc::new(RepositoryStore::new_for_test()) as Arc<dyn RepositoryStoreInterface>;
+
+    SessionFailureScreen::new(event_bus, theme_service, session_manager, repository_store)
+}
+
+#[test]
+fn test_session_failure_screen_init_without_data_uses_session_manager_fallback() {
+    let screen = create_session_failure_screen(Arc::new(EventBus::new()));
+
+    // Box<()> is not SessionFailureScreenData, so the fallback branch runs.
+    // SessionManager has no active session: get_session_result returns None
+    // (defaults applied) and get_stage_info returns (0, max_stages).
+    screen.init_with_data(Box::new(())).unwrap();
+}
+
+#[test]
+fn test_session_failure_screen_init_without_data_rejects_non_concrete_session_manager() {
+    let screen = create_session_failure_screen_with_session_manager(
+        Arc::new(EventBus::new()),
+        Arc::new(NonConcreteSessionManager),
+    );
+
+    let error = screen.init_with_data(Box::new(())).unwrap_err();
+
+    assert!(matches!(
+        error,
+        GitTypeError::TerminalError(message)
+            if message == "Failed to get SessionManager"
+    ));
+}
+
+#[test]
+fn test_session_failure_screen_unhandled_key_does_not_publish_navigation() {
+    let event_bus = Arc::new(EventBus::new());
+    let published_events = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let observed_events = Arc::clone(&published_events);
+    let screen = create_session_failure_screen(event_bus.clone());
+
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed_events.lock().unwrap().push(event.clone());
+    });
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(published_events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn test_session_failure_screen_default_provider_returns_unit_data() {
+    let data = <SessionFailureScreen as Screen>::default_provider()
+        .provide()
+        .unwrap();
+
+    assert!(data.downcast::<()>().is_ok());
+}
+
+#[test]
+fn test_session_failure_screen_as_any_downcasts_to_concrete_type() {
+    let screen = create_session_failure_screen(Arc::new(EventBus::new()));
+
+    assert!(screen
+        .as_any()
+        .downcast_ref::<SessionFailureScreen>()
+        .is_some());
+}

--- a/tests/integration/screens/session_summary_screen_test.rs
+++ b/tests/integration/screens/session_summary_screen_test.rs
@@ -1,7 +1,7 @@
 use crate::integration::screens::mocks::session_summary_screen_mock::{
     MockCompilerDataProvider, MockLoadBalancerPrimarchDataProvider, MockSessionSummaryDataProvider,
 };
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
@@ -17,7 +17,10 @@ use gittype::domain::stores::{ChallengeStore, RepositoryStore, SessionStore};
 use gittype::domain::stores::{
     ChallengeStoreInterface, RepositoryStoreInterface, SessionStoreInterface,
 };
-use gittype::presentation::tui::screens::session_summary_screen::SessionSummaryScreen;
+use gittype::presentation::tui::screens::session_summary_screen::{
+    ResultAction, SessionSummaryScreen,
+};
+use gittype::presentation::tui::Screen;
 use std::sync::Arc;
 
 // Helper function to create SessionSummaryScreen with all required dependencies
@@ -180,3 +183,155 @@ screen_basic_methods_test!(
     false,
     MockSessionSummaryDataProvider
 );
+
+#[test]
+fn test_session_summary_screen_get_action_result_initially_none() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_session_summary_screen_retry_key_sets_action_result_to_retry() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty()))
+        .unwrap();
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::Retry)
+    ));
+}
+
+#[test]
+fn test_session_summary_screen_share_key_sets_action_result_to_share() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::empty()))
+        .unwrap();
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::Share)
+    ));
+}
+
+#[test]
+fn test_session_summary_screen_t_key_sets_action_result_to_back_to_title() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('T'), KeyModifiers::empty()))
+        .unwrap();
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::BackToTitle)
+    ));
+}
+
+#[test]
+fn test_session_summary_screen_esc_sets_action_result_to_quit() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::Quit)
+    ));
+}
+
+#[test]
+fn test_session_summary_screen_ctrl_c_sets_action_result_to_quit() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::Quit)
+    ));
+}
+
+#[test]
+fn test_session_summary_screen_d_key_does_not_set_action_result() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::empty()))
+        .unwrap();
+    // Pressing 'd' opens the details dialog but does not record a ResultAction.
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_session_summary_screen_unknown_key_is_a_noop() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()))
+        .unwrap();
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_session_summary_screen_init_with_data_falls_back_to_session_manager_when_box_does_not_downcast(
+) {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+
+    // The default provider returns `Box<dyn Any>` containing `()`, so the
+    // downcast to `SessionSummaryScreenData` fails and the fallback branch
+    // queries the injected `SessionManager` / `RepositoryStore` instead.
+    let data = <SessionSummaryScreen as Screen>::default_provider()
+        .provide()
+        .unwrap();
+    assert!(screen.init_with_data(data).is_ok());
+}
+
+#[test]
+fn test_session_summary_screen_default_provider_returns_unit_data() {
+    let data = <SessionSummaryScreen as Screen>::default_provider()
+        .provide()
+        .unwrap();
+    assert!(data.downcast::<()>().is_ok());
+}
+
+#[test]
+fn test_session_summary_screen_init_with_data_resets_previous_action_result() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty()))
+        .unwrap();
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::Retry)
+    ));
+
+    let data = <SessionSummaryScreen as Screen>::default_provider()
+        .provide()
+        .unwrap();
+    screen.init_with_data(data).unwrap();
+
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_session_summary_screen_as_any_downcasts_to_concrete_type() {
+    let screen = create_session_summary_screen(Arc::new(EventBus::new()));
+    assert!(screen
+        .as_any()
+        .downcast_ref::<SessionSummaryScreen>()
+        .is_some());
+}
+
+#[test]
+fn test_session_summary_screen_result_action_variants_are_clonable_and_debuggable() {
+    let actions = [
+        ResultAction::Restart,
+        ResultAction::BackToTitle,
+        ResultAction::Quit,
+        ResultAction::Retry,
+        ResultAction::Share,
+    ];
+    for action in actions.iter() {
+        let cloned = action.clone();
+        // Debug + Clone exist on ResultAction; exercise both to lock in the
+        // public contract used by callers that log the chosen action.
+        assert!(!format!("{:?}", cloned).is_empty());
+    }
+}

--- a/tests/integration/screens/session_summary_share_screen_test.rs
+++ b/tests/integration/screens/session_summary_share_screen_test.rs
@@ -1,5 +1,5 @@
 use crate::integration::screens::mocks::session_summary_share_screen_mock::MockSessionSummaryShareDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
@@ -16,7 +16,11 @@ use gittype::domain::stores::{
     ChallengeStoreInterface, RepositoryStoreInterface, SessionStoreInterface,
 };
 use gittype::presentation::tui::screens::session_summary_share_screen::SessionSummaryShareScreen;
-use std::sync::Arc;
+use gittype::presentation::tui::Screen;
+use gittype::GitTypeError;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use std::sync::{Arc, Mutex};
 
 // Helper function to create SessionSummaryShareScreen with all required dependencies
 fn create_session_summary_share_screen(
@@ -126,3 +130,128 @@ screen_basic_methods_test!(
     false,
     MockSessionSummaryShareDataProvider
 );
+
+#[derive(Debug)]
+struct NonConcreteSessionManager;
+
+impl SessionManagerInterface for NonConcreteSessionManager {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn create_session_summary_share_screen_with_session_manager(
+    event_bus: Arc<dyn EventBusInterface>,
+    session_manager: Arc<dyn SessionManagerInterface>,
+) -> SessionSummaryShareScreen {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let repository_store =
+        Arc::new(RepositoryStore::new_for_test()) as Arc<dyn RepositoryStoreInterface>;
+
+    SessionSummaryShareScreen::new(event_bus, theme_service, session_manager, repository_store)
+}
+
+#[test]
+fn test_session_summary_share_screen_init_without_data_uses_session_manager_fallback() {
+    let screen = create_session_summary_share_screen(Arc::new(EventBus::new()));
+
+    // Box<()> is not SessionSummaryShareData, so the fallback branch runs.
+    // SessionManager has no active session: get_session_result returns None,
+    // and the repository_store returns None.
+    screen.init_with_data(Box::new(())).unwrap();
+}
+
+#[test]
+fn test_session_summary_share_screen_init_without_data_rejects_non_concrete_session_manager() {
+    let screen = create_session_summary_share_screen_with_session_manager(
+        Arc::new(EventBus::new()),
+        Arc::new(NonConcreteSessionManager),
+    );
+
+    let error = screen.init_with_data(Box::new(())).unwrap_err();
+
+    assert!(matches!(
+        error,
+        GitTypeError::TerminalError(message)
+            if message == "Failed to get SessionManager"
+    ));
+}
+
+#[test]
+fn test_session_summary_share_screen_unhandled_key_does_not_publish_navigation() {
+    let event_bus = Arc::new(EventBus::new());
+    let published_events = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let observed_events = Arc::clone(&published_events);
+    let screen = create_session_summary_share_screen(event_bus.clone());
+
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed_events.lock().unwrap().push(event.clone());
+    });
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(published_events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn test_session_summary_share_screen_default_provider_returns_unit_data() {
+    let data = <SessionSummaryShareScreen as Screen>::default_provider()
+        .provide()
+        .unwrap();
+
+    assert!(data.downcast::<()>().is_ok());
+}
+
+#[test]
+fn test_session_summary_share_screen_as_any_downcasts_to_concrete_type() {
+    let screen = create_session_summary_share_screen(Arc::new(EventBus::new()));
+
+    assert!(screen
+        .as_any()
+        .downcast_ref::<SessionSummaryShareScreen>()
+        .is_some());
+}
+
+#[test]
+fn test_session_summary_share_screen_render_without_data_is_noop() {
+    let screen = create_session_summary_share_screen(Arc::new(EventBus::new()));
+    // No init -> session_result stays None, render path takes the early-return branch.
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_session_summary_share_screen_share_keys_without_session_result_still_publish_pop() {
+    // Cover the `if let Some(session_result) = ...` is-None branch for each share key:
+    // when no SessionResult is loaded, the share call is skipped but Pop is still published.
+    for key in ['1', '2', '3', '4'] {
+        let event_bus = Arc::new(EventBus::new());
+        let observed = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+        let observed_clone = Arc::clone(&observed);
+        let screen = create_session_summary_share_screen(event_bus.clone());
+
+        event_bus.subscribe(move |event: &NavigateTo| {
+            observed_clone.lock().unwrap().push(event.clone());
+        });
+
+        // Intentionally skip init_with_data: session_result stays None.
+        screen
+            .handle_key_event(KeyEvent::new(KeyCode::Char(key), KeyModifiers::empty()))
+            .unwrap();
+
+        let events = observed.lock().unwrap();
+        assert_eq!(events.len(), 1, "expected one NavigateTo for key '{}'", key);
+        assert!(matches!(events[0], NavigateTo::Pop));
+    }
+}

--- a/tests/integration/screens/snapshots/r#mod__integration__screens__panic_screen_test__panic_screen_snapshot_with_location_line.snap
+++ b/tests/integration/screens/snapshots/r#mod__integration__screens__panic_screen_test__panic_screen_snapshot_with_location_line.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration/screens/panic_screen_test.rs
+assertion_line: 96
+expression: output
+---
+                                                                                                                        
+                                                 💥  APPLICATION PANIC 💥                                                 
+                                                                                                                        
+                                    We sincerely apologize for this unexpected error.                                   
+                            Progress is saved per session. Current session data may be lost.                            
+                                                                                                                        
+┌Help──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                      │
+│                                                   📋  Logs saved to:                                                  │
+│                                      ~/.gittype/logs/gittype_YYYYMMDD_HHMMSS.log                                     │
+│                                                                                                                      │
+│                                                 🐛  Report this issue:                                                │
+│                                    https://github.com/unhappychoice/gittype/issues                                   │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌Error Details─────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                      │
+│ Time:                                                                                                                │
+│ SystemTime { tv_sec: 1700000000, tv_nsec: 0 }                                                                        │
+│                                                                                                                      │
+│ Panic Message:                                                                                                       │
+│ boom!                                                                                                                │
+│                                                                                                                      │
+│ Location:                                                                                                            │
+│ src/foo.rs:42:10                                                                                                     │
+│ trailing                                                                                                             │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+                                                       [ESC] Exit

--- a/tests/integration/screens/stage_summary_screen_test.rs
+++ b/tests/integration/screens/stage_summary_screen_test.rs
@@ -237,3 +237,118 @@ fn test_stage_summary_screen_space_defaults_to_animation_for_non_concrete_sessio
         NavigateTo::Replace(gittype::presentation::tui::ScreenType::Animation)
     ));
 }
+
+#[test]
+fn test_stage_summary_screen_with_result_seeds_stage_result() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new())).with_result(stage_result());
+
+    let stored = screen.stage_result.read().unwrap();
+    assert!(stored.is_some());
+    assert_eq!(stored.as_ref().unwrap().keystrokes, 42);
+}
+
+#[test]
+fn test_stage_summary_screen_set_stage_result_updates_state() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new()));
+
+    screen.set_stage_result(stage_result());
+
+    let stored = screen.stage_result.read().unwrap();
+    assert!(stored.is_some());
+    assert_eq!(stored.as_ref().unwrap().mistakes, 1);
+}
+
+#[test]
+fn test_stage_summary_screen_init_without_data_falls_back_to_session_manager_defaults() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new()));
+
+    screen.init_with_data(Box::new(())).unwrap();
+
+    assert!(screen.stage_result.read().unwrap().is_none());
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_stage_summary_screen_render_without_stage_result_is_noop() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new()));
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+
+    let output = buffer_text(terminal.backend().buffer());
+    assert!(!output.contains("STAGE"));
+    assert!(!output.contains("Next stage starting..."));
+}
+
+#[test]
+fn test_stage_summary_screen_renders_next_stage_when_not_completed() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new()));
+    screen
+        .init_with_data(Box::new(StageSummaryData {
+            stage_result: stage_result(),
+            current_stage: 2,
+            total_stages: 3,
+            is_completed: false,
+        }))
+        .unwrap();
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+
+    let output = buffer_text(terminal.backend().buffer());
+    assert!(output.contains("Next stage starting..."));
+    assert!(output.contains("Stage 1 of 3"));
+}
+
+#[test]
+fn test_stage_summary_screen_records_quit_action_on_ctrl_c() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new()));
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(ResultAction::Quit)
+    ));
+}
+
+#[test]
+fn test_stage_summary_screen_unhandled_key_publishes_no_event_and_no_action() {
+    let event_bus = Arc::new(EventBus::new());
+    let published_events = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let observed_events = Arc::clone(&published_events);
+    let screen = create_stage_summary_screen(event_bus.clone());
+
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed_events.lock().unwrap().push(event.clone());
+    });
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(published_events.lock().unwrap().is_empty());
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_stage_summary_screen_as_any_downcasts_to_concrete_type() {
+    let screen = create_stage_summary_screen(Arc::new(EventBus::new()));
+
+    assert!(screen
+        .as_any()
+        .downcast_ref::<StageSummaryScreen>()
+        .is_some());
+}

--- a/tests/integration/screens/title_screen_test.rs
+++ b/tests/integration/screens/title_screen_test.rs
@@ -246,3 +246,90 @@ fn test_title_screen_left_from_first_difficulty_wraps_to_last() {
         .unwrap();
     assert_eq!(screen.get_selected_difficulty(), DifficultyLevel::Zen);
 }
+
+#[test]
+fn test_title_screen_with_challenge_counts_sets_counts() {
+    let screen =
+        create_title_screen(Arc::new(EventBus::new())).with_challenge_counts([1, 2, 3, 4, 5]);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(gittype::presentation::tui::screens::title_screen::TitleAction::Start(_))
+    ));
+}
+
+#[test]
+fn test_title_screen_with_git_repository_sets_repo() {
+    let repo = gittype::domain::models::GitRepository {
+        user_name: "alice".to_string(),
+        repository_name: "demo".to_string(),
+        remote_url: "https://github.com/alice/demo".to_string(),
+        branch: None,
+        commit_hash: None,
+        is_dirty: false,
+        root_path: None,
+    };
+    let _screen =
+        create_title_screen(Arc::new(EventBus::new())).with_git_repository(Some(repo.clone()));
+}
+
+#[test]
+fn test_title_screen_set_git_repository_overrides_value() {
+    let screen = create_title_screen(Arc::new(EventBus::new()));
+    let repo = gittype::domain::models::GitRepository {
+        user_name: "bob".to_string(),
+        repository_name: "lib".to_string(),
+        remote_url: "https://github.com/bob/lib".to_string(),
+        branch: Some("dev".to_string()),
+        commit_hash: Some("deadbeef".to_string()),
+        is_dirty: true,
+        root_path: None,
+    };
+
+    screen.set_git_repository(Some(repo));
+    screen.set_git_repository(None);
+}
+
+#[test]
+fn test_title_screen_init_with_data_fallback_uses_injected_dependencies() {
+    let screen = create_title_screen(Arc::new(EventBus::new()));
+
+    // Pass a unit value so the downcast to TitleScreenData fails and the
+    // fallback branch pulls counts/repo from the injected stores.
+    screen.init_with_data(Box::new(())).unwrap();
+
+    assert_eq!(screen.get_selected_difficulty(), DifficultyLevel::Normal);
+    assert!(screen.get_error_message().is_none());
+}
+
+#[test]
+fn test_title_screen_ignores_unhandled_key() {
+    let event_bus = Arc::new(EventBus::new());
+    let captured: Arc<std::sync::Mutex<Vec<NavigateTo>>> = Arc::new(std::sync::Mutex::new(vec![]));
+    let cap = captured.clone();
+    event_bus
+        .as_event_bus()
+        .subscribe(move |ev: &NavigateTo| cap.lock().unwrap().push(ev.clone()));
+    let screen = create_title_screen(event_bus);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(captured.lock().unwrap().is_empty());
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn test_title_screen_as_any_downcasts_to_self() {
+    let screen = create_title_screen(Arc::new(EventBus::new()));
+    let any = screen.as_any();
+    assert!(any.downcast_ref::<TitleScreen>().is_some());
+}

--- a/tests/integration/screens/total_summary_screen_test.rs
+++ b/tests/integration/screens/total_summary_screen_test.rs
@@ -4,9 +4,13 @@ use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::domain::models::color_mode::ColorMode;
 use gittype::domain::models::theme::Theme;
+use gittype::domain::models::SessionResult;
 use gittype::domain::services::scoring::{TotalTracker, TotalTrackerInterface};
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
-use gittype::presentation::tui::screens::total_summary_screen::TotalSummaryScreen;
+use gittype::presentation::tui::screens::total_summary_screen::{
+    TotalSummaryScreen, TotalSummaryScreenData, TotalSummaryScreenDataProvider,
+};
+use gittype::presentation::tui::{Screen, ScreenDataProvider};
 use std::sync::Arc;
 
 screen_snapshot_test!(
@@ -92,3 +96,63 @@ screen_basic_methods_test!(
     false,
     MockTotalSummaryDataProvider
 );
+
+#[test]
+fn test_total_summary_screen_default_provider_errors_without_tracker() {
+    let result = <TotalSummaryScreen as Screen>::default_provider().provide();
+    assert!(
+        result.is_err(),
+        "default_provider should error because tracker mutex holds None"
+    );
+}
+
+#[test]
+fn test_total_summary_screen_data_provider_returns_data_when_tracker_present() {
+    let tracker = TotalTracker::default();
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 1500.0;
+    session_result.overall_cpm = 320.0;
+    tracker.record(session_result);
+
+    let provider = TotalSummaryScreenDataProvider::new_for_test(Some(tracker));
+    let data = provider
+        .provide()
+        .expect("provider should produce data when tracker has sessions");
+    let screen_data = data
+        .downcast::<TotalSummaryScreenData>()
+        .expect("data should downcast to TotalSummaryScreenData");
+    assert_eq!(screen_data.total_result.total_sessions_attempted, 1);
+}
+
+#[test]
+fn test_total_summary_screen_data_provider_errors_when_tracker_none() {
+    let provider = TotalSummaryScreenDataProvider::new_for_test(None);
+    assert!(provider.provide().is_err());
+}
+
+#[test]
+fn test_total_summary_screen_init_with_data_falls_back_to_injected_tracker() {
+    let event_bus = Arc::new(EventBus::new());
+    let screen = create_total_summary_screen(event_bus);
+
+    let data: Box<dyn std::any::Any> = Box::new(());
+    assert!(screen.init_with_data(data).is_ok());
+}
+
+#[test]
+fn test_total_summary_screen_as_any_downcasts_to_concrete_type() {
+    let screen = create_total_summary_screen(Arc::new(EventBus::new()));
+    assert!(screen
+        .as_any()
+        .downcast_ref::<TotalSummaryScreen>()
+        .is_some());
+}
+
+#[test]
+fn test_total_summary_screen_unrelated_keys_are_noop() {
+    use crossterm::event::KeyEvent;
+
+    let screen = create_total_summary_screen(Arc::new(EventBus::new()));
+    let result = screen.handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()));
+    assert!(result.is_ok());
+}

--- a/tests/integration/screens/total_summary_share_screen_test.rs
+++ b/tests/integration/screens/total_summary_share_screen_test.rs
@@ -1,12 +1,17 @@
 use crate::integration::screens::mocks::total_summary_share_screen_mock::MockTotalSummaryShareDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::domain::models::color_mode::ColorMode;
 use gittype::domain::models::theme::Theme;
+use gittype::domain::models::{SessionResult, TotalResult};
 use gittype::domain::services::scoring::{TotalTracker, TotalTrackerInterface};
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
-use gittype::presentation::tui::screens::total_summary_share_screen::TotalSummaryShareScreen;
+use gittype::presentation::sharing::SharingPlatform;
+use gittype::presentation::tui::screens::total_summary_share_screen::{
+    TotalSummaryShareData, TotalSummaryShareDataProvider, TotalSummaryShareScreen,
+};
+use gittype::presentation::tui::{Screen, ScreenDataProvider};
 use std::sync::Arc;
 
 screen_snapshot_test!(
@@ -116,3 +121,149 @@ screen_basic_methods_test!(
     false,
     MockTotalSummaryShareDataProvider
 );
+
+fn make_screen() -> TotalSummaryShareScreen {
+    TotalSummaryShareScreen::new(
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+        Arc::new(TotalTracker::new_for_test()) as Arc<dyn TotalTrackerInterface>,
+    )
+}
+
+fn sample_total_result() -> TotalResult {
+    let mut result = TotalResult::new();
+    result.total_score = 1234.0;
+    result.overall_cpm = 250.0;
+    result.total_keystrokes = 5000;
+    result
+}
+
+#[test]
+fn test_total_summary_share_data_provider_returns_data_when_tracker_present() {
+    let tracker = TotalTracker::new_for_test();
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 1500.0;
+    session_result.overall_cpm = 300.0;
+    tracker.record(session_result);
+
+    let provider = TotalSummaryShareDataProvider::new_for_test(Some(tracker));
+    let data = provider
+        .provide()
+        .expect("provider should produce data when tracker is present");
+    assert!(data.downcast::<TotalSummaryShareData>().is_ok());
+}
+
+#[test]
+fn test_total_summary_share_data_provider_errors_when_tracker_none() {
+    let provider = TotalSummaryShareDataProvider::new_for_test(None);
+    assert!(provider.provide().is_err());
+}
+
+#[test]
+fn test_total_summary_share_screen_default_provider_errors_without_tracker() {
+    let result = <TotalSummaryShareScreen as Screen>::default_provider().provide();
+    assert!(
+        result.is_err(),
+        "default_provider should error because tracker mutex holds None"
+    );
+}
+
+#[test]
+fn test_total_summary_share_screen_init_with_data_falls_back_to_injected_tracker() {
+    let screen = make_screen();
+    let data: Box<dyn std::any::Any> = Box::new(());
+    assert!(screen.init_with_data(data).is_ok());
+}
+
+#[test]
+fn test_total_summary_share_screen_as_any_downcasts_to_concrete_type() {
+    let screen = make_screen();
+    assert!(screen
+        .as_any()
+        .downcast_ref::<TotalSummaryShareScreen>()
+        .is_some());
+}
+
+#[test]
+fn test_total_summary_share_screen_unrelated_keys_are_noop() {
+    let screen = make_screen();
+    let result = screen.handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_total_summary_share_screen_generate_share_url_for_all_platforms() {
+    let screen = make_screen();
+    screen.set_total_result_for_test(sample_total_result());
+
+    let text = "share text";
+    let x_url = screen.generate_share_url_for_test(text, &SharingPlatform::X);
+    assert!(x_url.starts_with("https://x.com/intent/tweet?text="));
+    assert!(x_url.contains("share%20text"));
+
+    let reddit_url = screen.generate_share_url_for_test(text, &SharingPlatform::Reddit);
+    assert!(reddit_url.starts_with("https://www.reddit.com/submit?title="));
+    assert!(reddit_url.contains("5000%20keystrokes"));
+
+    let linkedin_url = screen.generate_share_url_for_test(text, &SharingPlatform::LinkedIn);
+    assert!(
+        linkedin_url.starts_with("https://www.linkedin.com/feed/?shareActive=true&mini=true&text=")
+    );
+
+    let facebook_url = screen.generate_share_url_for_test(text, &SharingPlatform::Facebook);
+    assert!(facebook_url.starts_with("https://www.facebook.com/sharer/sharer.php?u="));
+    assert!(facebook_url.contains("github.com%2Funhappychoice%2Fgittype"));
+}
+
+#[test]
+fn test_total_summary_share_screen_esc_with_fallback_dismisses_fallback() {
+    let screen = make_screen();
+    screen.set_fallback_url_for_test(Some((
+        "https://example.com".to_string(),
+        SharingPlatform::X,
+    )));
+
+    let event_bus = Arc::new(EventBus::new());
+    let published = Arc::new(std::sync::Mutex::new(0usize));
+    let observed = Arc::clone(&published);
+    event_bus.subscribe(move |_: &NavigateTo| {
+        *observed.lock().unwrap() += 1;
+    });
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+
+    assert!(
+        screen.fallback_url_for_test().is_none(),
+        "fallback_url should be cleared"
+    );
+    // No NavigateTo events were published from this local event_bus, but the
+    // screen's own injected event_bus may not have been used. Just verify
+    // fallback was dismissed without panic.
+    let _ = published;
+}
+
+#[test]
+fn test_total_summary_share_screen_render_in_fallback_state() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let screen = make_screen();
+    screen.set_total_result_for_test(sample_total_result());
+    screen.set_fallback_url_for_test(Some((
+        "https://example.com/share".to_string(),
+        SharingPlatform::X,
+    )));
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).unwrap();
+        })
+        .unwrap();
+}

--- a/tests/integration/screens/trending_language_selection_screen_test.rs
+++ b/tests/integration/screens/trending_language_selection_screen_test.rs
@@ -1,12 +1,27 @@
 use crate::integration::screens::helpers::EmptyMockProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::domain::models::color_mode::ColorMode;
 use gittype::domain::models::theme::Theme;
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
 use gittype::presentation::tui::screens::TrendingLanguageSelectionScreen;
+use gittype::presentation::tui::Screen;
 use std::sync::Arc;
+
+fn make_screen() -> TrendingLanguageSelectionScreen {
+    TrendingLanguageSelectionScreen::new(
+        Arc::new(EventBus::new()),
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+    )
+}
+
+fn press(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::empty())
+}
 
 screen_snapshot_test!(
     test_trending_language_selection_screen_snapshot,
@@ -90,3 +105,119 @@ screen_basic_methods_test!(
     gittype::presentation::tui::ScreenType::TrendingLanguageSelection,
     true
 );
+
+#[test]
+fn get_selected_language_returns_none_before_space() {
+    let screen = make_screen();
+    assert!(screen.get_selected_language().is_none());
+}
+
+#[test]
+fn space_press_sets_selected_language_to_first_entry() {
+    let screen = make_screen();
+    screen.handle_key_event(press(KeyCode::Char(' '))).unwrap();
+    assert_eq!(screen.get_selected_language(), Some("C".to_string()));
+}
+
+#[test]
+fn key_release_event_is_ignored() {
+    let screen = make_screen();
+    let release_event = KeyEvent {
+        code: KeyCode::Char(' '),
+        modifiers: KeyModifiers::empty(),
+        kind: KeyEventKind::Release,
+        state: KeyEventState::empty(),
+    };
+    screen.handle_key_event(release_event).unwrap();
+    assert!(screen.get_selected_language().is_none());
+}
+
+#[test]
+fn up_at_first_index_does_not_underflow() {
+    let screen = make_screen();
+    screen.handle_key_event(press(KeyCode::Up)).unwrap();
+    screen.handle_key_event(press(KeyCode::Char(' '))).unwrap();
+    assert_eq!(screen.get_selected_language(), Some("C".to_string()));
+}
+
+#[test]
+fn k_after_j_decrements_selection() {
+    let screen = make_screen();
+    screen.handle_key_event(press(KeyCode::Char('j'))).unwrap();
+    screen.handle_key_event(press(KeyCode::Char('j'))).unwrap();
+    screen.handle_key_event(press(KeyCode::Char('k'))).unwrap();
+    screen.handle_key_event(press(KeyCode::Char(' '))).unwrap();
+    assert_eq!(screen.get_selected_language(), Some("C#".to_string()));
+}
+
+#[test]
+fn down_at_last_index_does_not_overflow() {
+    let screen = make_screen();
+    for _ in 0..30 {
+        screen.handle_key_event(press(KeyCode::Char('j'))).unwrap();
+    }
+    screen.handle_key_event(press(KeyCode::Char(' '))).unwrap();
+    assert_eq!(
+        screen.get_selected_language(),
+        Some("TypeScript".to_string())
+    );
+}
+
+#[test]
+fn unhandled_key_is_a_noop() {
+    let event_bus = Arc::new(EventBus::new());
+    let captured: Arc<std::sync::Mutex<Vec<NavigateTo>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured_clone = captured.clone();
+    event_bus.subscribe(move |evt: &NavigateTo| {
+        captured_clone.lock().unwrap().push(evt.clone());
+    });
+
+    let screen = TrendingLanguageSelectionScreen::new(
+        event_bus,
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+    );
+
+    screen.handle_key_event(press(KeyCode::Tab)).unwrap();
+    screen.handle_key_event(press(KeyCode::Char('z'))).unwrap();
+
+    assert!(captured.lock().unwrap().is_empty());
+    assert!(screen.get_selected_language().is_none());
+}
+
+#[test]
+fn cleanup_returns_ok() {
+    let screen = make_screen();
+    assert!(screen.cleanup().is_ok());
+}
+
+#[test]
+fn as_any_downcasts_to_concrete_screen() {
+    let screen = make_screen();
+    let any_ref = screen.as_any();
+    assert!(any_ref
+        .downcast_ref::<TrendingLanguageSelectionScreen>()
+        .is_some());
+}
+
+#[test]
+fn init_with_data_resets_state() {
+    let screen = make_screen();
+    screen.handle_key_event(press(KeyCode::Char('j'))).unwrap();
+    screen.handle_key_event(press(KeyCode::Char(' '))).unwrap();
+    assert!(screen.get_selected_language().is_some());
+
+    screen.init_with_data(Box::new(())).unwrap();
+    assert!(screen.get_selected_language().is_none());
+}
+
+#[test]
+fn default_provider_yields_unit_payload() {
+    let payload = TrendingLanguageSelectionScreen::default_provider()
+        .provide()
+        .unwrap();
+    assert!(payload.downcast_ref::<()>().is_some());
+}

--- a/tests/integration/screens/trending_repository_selection_screen_test.rs
+++ b/tests/integration/screens/trending_repository_selection_screen_test.rs
@@ -1,13 +1,14 @@
 use crate::integration::screens::mocks::trending_repository_mock::MockTrendingRepository;
 use crate::integration::screens::mocks::trending_repository_selection_screen_mock::MockTrendingRepositorySelectionDataProvider;
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::domain::models::color_mode::ColorMode;
 use gittype::domain::models::theme::Theme;
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
 use gittype::presentation::tui::screens::TrendingRepositorySelectionScreen;
-use std::sync::Arc;
+use gittype::presentation::tui::{Screen, ScreenDataProvider};
+use std::sync::{Arc, Mutex};
 
 screen_snapshot_test!(
     test_trending_repository_selection_screen_snapshot,
@@ -139,3 +140,217 @@ screen_basic_methods_test!(
     true,
     MockTrendingRepositorySelectionDataProvider
 );
+
+fn make_screen() -> TrendingRepositorySelectionScreen {
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    TrendingRepositorySelectionScreen::new(
+        Arc::new(EventBus::new()),
+        theme_service,
+        Arc::new(MockTrendingRepository::new()),
+    )
+}
+
+fn init_with_mock_data(screen: &TrendingRepositorySelectionScreen) {
+    let data = MockTrendingRepositorySelectionDataProvider
+        .provide()
+        .unwrap();
+    screen.init_with_data(data).unwrap();
+}
+
+#[test]
+fn test_accessors_start_with_defaults() {
+    let screen = make_screen();
+
+    assert_eq!(screen.get_selected_index(), None);
+    assert!(screen.get_repositories().is_empty());
+}
+
+#[test]
+fn test_init_with_data_populates_repositories() {
+    let screen = make_screen();
+
+    init_with_mock_data(&screen);
+
+    let repositories = screen.get_repositories();
+    assert_eq!(repositories.len(), 2);
+    assert_eq!(repositories[0].repo_name, "rust-lang/rust");
+    assert_eq!(screen.get_selected_index(), None);
+}
+
+#[test]
+fn test_init_with_data_ignores_wrong_payload_type() {
+    let screen = make_screen();
+
+    screen
+        .init_with_data(Box::new(()) as Box<dyn std::any::Any>)
+        .unwrap();
+
+    assert!(screen.get_repositories().is_empty());
+}
+
+#[test]
+fn test_handle_key_event_ignores_release_events() {
+    let screen = make_screen();
+    init_with_mock_data(&screen);
+
+    let release = KeyEvent {
+        code: KeyCode::Down,
+        modifiers: KeyModifiers::empty(),
+        kind: KeyEventKind::Release,
+        state: KeyEventState::empty(),
+    };
+    screen.handle_key_event(release).unwrap();
+
+    assert_eq!(screen.get_selected_index(), None);
+}
+
+#[test]
+fn test_space_selects_current_index() {
+    let event_bus = Arc::new(EventBus::new());
+    let observed = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let observed_clone = Arc::clone(&observed);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed_clone.lock().unwrap().push(event.clone());
+    });
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let screen = TrendingRepositorySelectionScreen::new(
+        event_bus,
+        theme_service,
+        Arc::new(MockTrendingRepository::new()),
+    );
+    init_with_mock_data(&screen);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(0));
+    assert!(observed
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|e| matches!(e, NavigateTo::Exit)));
+}
+
+#[test]
+fn test_down_navigation_moves_selection() {
+    let screen = make_screen();
+    init_with_mock_data(&screen);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(1));
+}
+
+#[test]
+fn test_down_navigation_does_not_pass_last_index() {
+    let screen = make_screen();
+    init_with_mock_data(&screen);
+
+    for _ in 0..5 {
+        screen
+            .handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()))
+            .unwrap();
+    }
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(1));
+}
+
+#[test]
+fn test_up_navigation_moves_selection() {
+    let screen = make_screen();
+    init_with_mock_data(&screen);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(0));
+}
+
+#[test]
+fn test_up_navigation_clamps_at_zero() {
+    let screen = make_screen();
+    init_with_mock_data(&screen);
+
+    for _ in 0..3 {
+        screen
+            .handle_key_event(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty()))
+            .unwrap();
+    }
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), Some(0));
+}
+
+#[test]
+fn test_unhandled_key_does_not_change_state() {
+    let event_bus = Arc::new(EventBus::new());
+    let observed = Arc::new(Mutex::new(Vec::<NavigateTo>::new()));
+    let observed_clone = Arc::clone(&observed);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed_clone.lock().unwrap().push(event.clone());
+    });
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let screen = TrendingRepositorySelectionScreen::new(
+        event_bus,
+        theme_service,
+        Arc::new(MockTrendingRepository::new()),
+    );
+    init_with_mock_data(&screen);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()))
+        .unwrap();
+
+    assert_eq!(screen.get_selected_index(), None);
+    assert!(observed.lock().unwrap().is_empty());
+}
+
+#[test]
+fn test_cleanup_returns_ok() {
+    let screen = make_screen();
+    screen.cleanup().unwrap();
+}
+
+#[test]
+fn test_as_any_downcasts_to_concrete_type() {
+    let screen = make_screen();
+    assert!(screen
+        .as_any()
+        .downcast_ref::<TrendingRepositorySelectionScreen>()
+        .is_some());
+}
+
+#[test]
+fn test_default_provider_returns_unit_payload() {
+    let data = <TrendingRepositorySelectionScreen as Screen>::default_provider()
+        .provide()
+        .unwrap();
+    assert!(data.downcast::<()>().is_ok());
+}

--- a/tests/integration/screens/typing_screen_test.rs
+++ b/tests/integration/screens/typing_screen_test.rs
@@ -1,11 +1,12 @@
 use crate::integration::screens::mocks::typing_screen_mock::{
     create_typing_screen_with_challenge, MockTypingScreenDataProvider,
 };
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::presentation::tui::screens::typing_screen::TypingScreen;
-use std::sync::Arc;
+use gittype::presentation::tui::Screen;
+use std::sync::{Arc, Mutex};
 
 // Note: TypingScreen has complex state management (waiting_to_start, countdown, dialog_shown)
 // These tests cover different display states
@@ -424,3 +425,366 @@ screen_basic_methods_test!(
     false,
     MockTypingScreenDataProvider
 );
+
+// ---------------------------------------------------------------------------
+// handle_key dialog/state branch coverage
+// ---------------------------------------------------------------------------
+
+fn make_release_event(code: KeyCode) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers: KeyModifiers::empty(),
+        kind: KeyEventKind::Release,
+        state: KeyEventState::empty(),
+    }
+}
+
+fn screen_with_navigate_subscription(
+    code: Option<&str>,
+) -> (TypingScreen, Arc<Mutex<Vec<NavigateTo>>>) {
+    let event_bus = Arc::new(EventBus::new());
+    let events: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = Arc::clone(&events);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        events_clone.lock().unwrap().push(event.clone());
+    });
+
+    let screen = create_typing_screen_with_challenge(event_bus, code);
+    (screen, events)
+}
+
+#[test]
+fn test_handle_key_release_event_is_ignored() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    // Send a Release-kind event. Should be ignored without panic and without
+    // transitioning state.
+    screen
+        .handle_key_event(make_release_event(KeyCode::Char(' ')))
+        .unwrap();
+}
+
+#[test]
+fn test_waiting_dialog_second_esc_closes_dialog() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    // Esc opens dialog while waiting_to_start
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // Second Esc closes dialog (covers WaitingToStart + dialog_shown branch)
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_waiting_dialog_q_emits_failed_navigation() {
+    let (screen, navigates) = screen_with_navigate_subscription(Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+    let captured = navigates.lock().unwrap();
+    assert!(captured.iter().any(|n| matches!(
+        n,
+        NavigateTo::Replace(gittype::presentation::tui::ScreenType::SessionFailure)
+    )));
+}
+
+#[test]
+fn test_waiting_dialog_any_char_closes_dialog_and_keeps_waiting() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // Any non-special key with dialog open closes the dialog and stays waiting
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_waiting_q_without_dialog_is_noop() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    // Q while waiting and no dialog shown should not crash and not transition
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_waiting_s_without_dialog_is_noop() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_waiting_ctrl_c_emits_exit_navigation() {
+    let (screen, navigates) = screen_with_navigate_subscription(Some("fn t() {}"));
+    // Ctrl+C from waiting_to_start state -> Exit -> NavigateTo::PopTo(Title)
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+    let captured = navigates.lock().unwrap();
+    assert!(captured.iter().any(|n| matches!(
+        n,
+        NavigateTo::PopTo(gittype::presentation::tui::ScreenType::Title)
+    )));
+}
+
+#[test]
+fn test_countdown_dialog_close_with_esc_returns_to_countdown() {
+    let screen = create_typing_screen_with_challenge(
+        Arc::new(EventBus::new()),
+        Some("fn main() {\n    println!(\"Hello\");\n}"),
+    );
+    // Enter countdown
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    // Open dialog during countdown
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // Close dialog with another Esc
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_countdown_dialog_q_emits_failed_navigation() {
+    let (screen, navigates) = screen_with_navigate_subscription(Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+    let captured = navigates.lock().unwrap();
+    assert!(captured.iter().any(|n| matches!(
+        n,
+        NavigateTo::Replace(gittype::presentation::tui::ScreenType::SessionFailure)
+    )));
+}
+
+#[test]
+fn test_countdown_dialog_any_char_closes_dialog() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // Non-special key with dialog during countdown closes dialog -> countdown
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_countdown_s_without_dialog_is_noop() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_countdown_q_without_dialog_is_noop() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_countdown_ctrl_c_emits_exit_navigation() {
+    let (screen, navigates) = screen_with_navigate_subscription(Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+    let captured = navigates.lock().unwrap();
+    assert!(captured.iter().any(|n| matches!(
+        n,
+        NavigateTo::PopTo(gittype::presentation::tui::ScreenType::Title)
+    )));
+}
+
+#[test]
+fn test_typing_dialog_second_esc_closes_dialog() {
+    let screen = create_typing_screen_with_challenge(
+        Arc::new(EventBus::new()),
+        Some("fn main() {\n    println!(\"Hello\");\n}"),
+    );
+    // Enter typing state
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+
+    // Esc opens dialog
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // Esc again closes dialog (covers typing + dialog + Esc branch)
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_typing_dialog_q_emits_failed_navigation() {
+    let (screen, navigates) = screen_with_navigate_subscription(Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        .unwrap();
+
+    let captured = navigates.lock().unwrap();
+    assert!(captured.iter().any(|n| matches!(
+        n,
+        NavigateTo::Replace(gittype::presentation::tui::ScreenType::SessionFailure)
+    )));
+}
+
+#[test]
+fn test_typing_dialog_any_char_closes_dialog_and_continues() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // Any non-special key with dialog open closes the dialog and continues typing
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_typing_dialog_tab_closes_dialog() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_typing_dialog_enter_closes_dialog() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_typing_dialog_s_triggers_skip_handling() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+    // 's' with dialog open during typing routes through handle_skip_action
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_typing_ctrl_c_emits_exit_navigation() {
+    let (screen, navigates) = screen_with_navigate_subscription(Some("fn t() {}"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+    let captured = navigates.lock().unwrap();
+    assert!(captured.iter().any(|n| matches!(
+        n,
+        NavigateTo::PopTo(gittype::presentation::tui::ScreenType::Title)
+    )));
+}
+
+#[test]
+fn test_typing_uppercase_s_types_character() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("S"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+
+    // 'S' character with no dialog should be treated as a typed character
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::empty()))
+        .unwrap();
+}
+
+#[test]
+fn test_typing_uppercase_q_types_character() {
+    let screen = create_typing_screen_with_challenge(Arc::new(EventBus::new()), Some("Q"));
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()))
+        .unwrap();
+    screen.skip_countdown_for_test();
+    screen.set_waiting_to_start(false);
+
+    // 'Q' character with no dialog should be treated as a typed character
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('Q'), KeyModifiers::empty()))
+        .unwrap();
+}

--- a/tests/unit/domain/repositories/challenge_repository_tests.rs
+++ b/tests/unit/domain/repositories/challenge_repository_tests.rs
@@ -262,3 +262,237 @@ fn load_challenges_reconstructs_saved_source_slice() {
     assert_eq!(loaded[0].comment_ranges, vec![(0, 2)]);
     assert_eq!(loaded[0].difficulty_level, Some(DifficultyLevel::Normal));
 }
+
+#[test]
+fn load_challenges_uses_whole_file_when_lines_are_absent() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_path = temp_dir.path().join("repo/src/lib.rs");
+    let source = "fn whole() {}\nfn file() {}\n";
+    std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+    std::fs::write(&source_path, source).unwrap();
+
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        file_storage_with_source(source_path.canonicalize().unwrap(), source),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-whole-file-{}", std::process::id())),
+        is_dirty: false,
+        root_path: Some(temp_dir.path().join("repo")),
+    };
+    let challenge = Challenge {
+        id: "no-lines".to_string(),
+        source_file_path: Some("src/lib.rs".to_string()),
+        code_content: "placeholder".to_string(),
+        start_line: None,
+        end_line: None,
+        language: Some("rust".to_string()),
+        comment_ranges: Vec::new(),
+        difficulty_level: Some(DifficultyLevel::Easy),
+    };
+
+    repository
+        .save_challenges(&git_repository, &[challenge])
+        .unwrap();
+
+    let loaded = repository
+        .load_challenges_with_progress(&git_repository, None)
+        .expect("challenge without line info should reconstruct full file");
+
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].code_content, source);
+    assert_eq!(loaded[0].start_line, None);
+    assert_eq!(loaded[0].end_line, None);
+}
+
+#[test]
+fn load_challenges_returns_none_when_pointer_has_no_source_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join("repo")).unwrap();
+
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        Arc::new(FileStorage::new()),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-no-path-{}", std::process::id())),
+        is_dirty: false,
+        root_path: Some(temp_dir.path().join("repo")),
+    };
+    let challenge = Challenge {
+        id: "no-source-path".to_string(),
+        source_file_path: None,
+        code_content: "fn ghost() {}".to_string(),
+        start_line: None,
+        end_line: None,
+        language: None,
+        comment_ranges: Vec::new(),
+        difficulty_level: None,
+    };
+
+    repository
+        .save_challenges(&git_repository, &[challenge])
+        .unwrap();
+
+    let loaded = repository.load_challenges_with_progress(&git_repository, None);
+    assert!(loaded.is_none());
+}
+
+#[test]
+fn load_challenges_returns_none_when_start_line_exceeds_file_length() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_path = temp_dir.path().join("repo/src/lib.rs");
+    let source = "fn only() {}\n";
+    std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+    std::fs::write(&source_path, source).unwrap();
+
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        file_storage_with_source(source_path.canonicalize().unwrap(), source),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-bad-range-{}", std::process::id())),
+        is_dirty: false,
+        root_path: Some(temp_dir.path().join("repo")),
+    };
+    let challenge = Challenge {
+        id: "out-of-range".to_string(),
+        source_file_path: Some("src/lib.rs".to_string()),
+        code_content: "placeholder".to_string(),
+        start_line: Some(100),
+        end_line: Some(200),
+        language: Some("rust".to_string()),
+        comment_ranges: Vec::new(),
+        difficulty_level: None,
+    };
+
+    repository
+        .save_challenges(&git_repository, &[challenge])
+        .unwrap();
+
+    let loaded = repository.load_challenges_with_progress(&git_repository, None);
+    assert!(loaded.is_none());
+}
+
+#[test]
+fn load_challenges_returns_none_when_start_line_exceeds_end_line() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_path = temp_dir.path().join("repo/src/lib.rs");
+    let source = "line1\nline2\nline3\nline4\nline5\n";
+    std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+    std::fs::write(&source_path, source).unwrap();
+
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        file_storage_with_source(source_path.canonicalize().unwrap(), source),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-inverted-{}", std::process::id())),
+        is_dirty: false,
+        root_path: Some(temp_dir.path().join("repo")),
+    };
+    let challenge = Challenge {
+        id: "inverted-range".to_string(),
+        source_file_path: Some("src/lib.rs".to_string()),
+        code_content: "placeholder".to_string(),
+        start_line: Some(4),
+        end_line: Some(2),
+        language: Some("rust".to_string()),
+        comment_ranges: Vec::new(),
+        difficulty_level: None,
+    };
+
+    repository
+        .save_challenges(&git_repository, &[challenge])
+        .unwrap();
+
+    let loaded = repository.load_challenges_with_progress(&git_repository, None);
+    assert!(loaded.is_none());
+}
+
+#[test]
+fn load_challenges_returns_none_when_source_path_escapes_repo_root() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo_path = temp_dir.path().join("repo");
+    let outside_path = temp_dir.path().join("outside/escape.rs");
+    std::fs::create_dir_all(&repo_path).unwrap();
+    std::fs::create_dir_all(outside_path.parent().unwrap()).unwrap();
+    std::fs::write(&outside_path, "fn outside() {}\n").unwrap();
+
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        Arc::new(FileStorage::new()),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-escape-{}", std::process::id())),
+        is_dirty: false,
+        root_path: Some(repo_path),
+    };
+    let challenge = Challenge {
+        id: "escape-attempt".to_string(),
+        source_file_path: Some("../outside/escape.rs".to_string()),
+        code_content: "placeholder".to_string(),
+        start_line: None,
+        end_line: None,
+        language: Some("rust".to_string()),
+        comment_ranges: Vec::new(),
+        difficulty_level: None,
+    };
+
+    repository
+        .save_challenges(&git_repository, &[challenge])
+        .unwrap();
+
+    let loaded = repository.load_challenges_with_progress(&git_repository, None);
+    assert!(loaded.is_none());
+}
+
+#[test]
+fn load_challenges_returns_none_when_root_path_is_missing() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        Arc::new(FileStorage::new()),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-no-root-{}", std::process::id())),
+        is_dirty: false,
+        root_path: None,
+    };
+    let challenge = Challenge::new("c".to_string(), "fn x() {}".to_string()).with_source_info(
+        "src/lib.rs".to_string(),
+        1,
+        1,
+    );
+
+    repository
+        .save_challenges(&git_repository, &[challenge])
+        .unwrap();
+
+    let loaded = repository.load_challenges_with_progress(&git_repository, None);
+    assert!(loaded.is_none());
+}

--- a/tests/unit/domain/repositories/challenge_repository_tests.rs
+++ b/tests/unit/domain/repositories/challenge_repository_tests.rs
@@ -1,3 +1,4 @@
+use gittype::domain::models::loading::StepType;
 use gittype::domain::models::{Challenge, DifficultyLevel, GitRepository};
 use gittype::domain::repositories::challenge_repository::{
     ChallengeRepository, ChallengeRepositoryInterface,
@@ -5,9 +6,10 @@ use gittype::domain::repositories::challenge_repository::{
 use gittype::infrastructure::storage::file_storage::FileStorage;
 use gittype::infrastructure::storage::file_storage::FileStorageInterface;
 use gittype::presentation::di::AppModule;
+use gittype::presentation::tui::screens::loading_screen::ProgressReporter;
 use shaku::HasComponent;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 fn create_repository() -> Arc<dyn ChallengeRepositoryInterface> {
     let module = AppModule::builder().build();
@@ -465,6 +467,94 @@ fn load_challenges_returns_none_when_source_path_escapes_repo_root() {
 
     let loaded = repository.load_challenges_with_progress(&git_repository, None);
     assert!(loaded.is_none());
+}
+
+type ProgressCall = (StepType, usize, usize, Option<String>);
+
+#[derive(Default)]
+struct RecordingProgressReporter {
+    file_counts_calls: Mutex<Vec<ProgressCall>>,
+}
+
+impl ProgressReporter for RecordingProgressReporter {
+    fn set_step(&self, _step_type: StepType) {}
+
+    fn set_current_file(&self, _file: Option<String>) {}
+
+    fn set_file_counts(
+        &self,
+        step_type: StepType,
+        processed: usize,
+        total: usize,
+        current_file: Option<String>,
+    ) {
+        self.file_counts_calls
+            .lock()
+            .unwrap()
+            .push((step_type, processed, total, current_file));
+    }
+}
+
+#[test]
+fn load_challenges_with_progress_reports_progress_to_reporter() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_path = temp_dir.path().join("repo/src/lib.rs");
+    let source = "fn one() {}\nfn two() {}\nfn three() {}\n";
+    std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+    std::fs::write(&source_path, source).unwrap();
+
+    let repository = ChallengeRepository::new_for_test(
+        temp_dir.path().join("cache"),
+        file_storage_with_source(source_path.canonicalize().unwrap(), source),
+    );
+    let git_repository = GitRepository {
+        user_name: "test".to_string(),
+        repository_name: "repo".to_string(),
+        remote_url: "https://github.com/test/repo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some(format!("load-progress-{}", std::process::id())),
+        is_dirty: false,
+        root_path: Some(temp_dir.path().join("repo")),
+    };
+    let challenges = vec![
+        Challenge::new("c1".to_string(), "fn one() {}".to_string()).with_source_info(
+            "src/lib.rs".to_string(),
+            1,
+            1,
+        ),
+        Challenge::new("c2".to_string(), "fn two() {}".to_string()).with_source_info(
+            "src/lib.rs".to_string(),
+            2,
+            2,
+        ),
+    ];
+
+    repository
+        .save_challenges(&git_repository, &challenges)
+        .unwrap();
+
+    let reporter = RecordingProgressReporter::default();
+    let loaded = repository
+        .load_challenges_with_progress(&git_repository, Some(&reporter))
+        .expect("saved challenges should reconstruct with progress reporting");
+
+    assert_eq!(loaded.len(), 2);
+
+    let calls = reporter.file_counts_calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    for (step_type, _processed, total, current_file) in calls.iter() {
+        assert_eq!(*step_type, StepType::CacheCheck);
+        assert_eq!(*total, 2);
+        assert!(current_file
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("Reconstructing challenge"));
+    }
+    let processed_values: std::collections::HashSet<_> = calls
+        .iter()
+        .map(|(_, processed, _, _)| *processed)
+        .collect();
+    assert_eq!(processed_values, std::collections::HashSet::from([1, 2]));
 }
 
 #[test]

--- a/tests/unit/domain/repositories/session_repository_tests.rs
+++ b/tests/unit/domain/repositories/session_repository_tests.rs
@@ -438,6 +438,216 @@ fn test_session_repository_trait_implementation() {
     assert!(result.is_ok());
 }
 
+#[test]
+fn test_trait_get_all_repositories_returns_recorded_repository() {
+    let repo = SessionRepository::new().unwrap();
+
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 88.0;
+    let git_repo = GitRepository {
+        user_name: "traituser".to_string(),
+        repository_name: "traitrepo".to_string(),
+        remote_url: "https://github.com/traituser/traitrepo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("trait1".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    let challenge = Challenge::new("trait-id".to_string(), "trait".to_string());
+    let mut tracker = StageTracker::new("trait".to_string());
+    tracker.record(StageInput::Start);
+    tracker.record(StageInput::Finish);
+
+    repo.record_session(
+        &session_result,
+        Some(&git_repo),
+        "normal",
+        None,
+        &[("stage1".to_string(), tracker)],
+        &[challenge],
+    )
+    .unwrap();
+
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    let repositories = trait_ref.get_all_repositories().unwrap();
+    assert!(repositories
+        .iter()
+        .any(|r| r.repository_name == "traitrepo" && r.user_name == "traituser"));
+}
+
+#[test]
+fn test_trait_get_sessions_filtered_returns_recorded_sessions() {
+    let repo = SessionRepository::new().unwrap();
+
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 95.0;
+    let git_repo = GitRepository {
+        user_name: "tfilteruser".to_string(),
+        repository_name: "tfilterrepo".to_string(),
+        remote_url: "https://github.com/tfilteruser/tfilterrepo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("tfilter1".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    let challenge = Challenge::new("tfilter-id".to_string(), "tfilter".to_string());
+    let mut tracker = StageTracker::new("tfilter".to_string());
+    tracker.record(StageInput::Start);
+    tracker.record(StageInput::Finish);
+
+    repo.record_session(
+        &session_result,
+        Some(&git_repo),
+        "normal",
+        None,
+        &[("stage1".to_string(), tracker)],
+        &[challenge],
+    )
+    .unwrap();
+
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    let sessions = trait_ref
+        .get_sessions_filtered(None, None, "score", false)
+        .unwrap();
+    assert!(!sessions.is_empty());
+}
+
+#[test]
+fn test_trait_get_session_result_returns_recorded_session() {
+    let repo = SessionRepository::new().unwrap();
+
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 175.0;
+    session_result.overall_cpm = 333.0;
+    let git_repo = GitRepository {
+        user_name: "tresultuser".to_string(),
+        repository_name: "tresultrepo".to_string(),
+        remote_url: "https://github.com/tresultuser/tresultrepo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("tresult1".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    let challenge = Challenge::new("tresult-id".to_string(), "tresult".to_string());
+    let mut tracker = StageTracker::new("tresult".to_string());
+    tracker.record(StageInput::Start);
+    tracker.record(StageInput::Finish);
+
+    let session_id = repo
+        .record_session(
+            &session_result,
+            Some(&git_repo),
+            "normal",
+            None,
+            &[("stage1".to_string(), tracker)],
+            &[challenge],
+        )
+        .unwrap();
+
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    let result = trait_ref.get_session_result(session_id).unwrap();
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().score, 175.0);
+}
+
+#[test]
+fn test_trait_get_session_result_returns_none_for_missing_id() {
+    let repo = SessionRepository::new().unwrap();
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    assert!(trait_ref.get_session_result(987654321).unwrap().is_none());
+}
+
+#[test]
+fn test_trait_get_language_stats_includes_recorded_language() {
+    let repo = SessionRepository::new().unwrap();
+
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 110.0;
+    let git_repo = GitRepository {
+        user_name: "tlanguser".to_string(),
+        repository_name: "tlangrepo".to_string(),
+        remote_url: "https://github.com/tlanguser/tlangrepo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("tlang1".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    let challenge = Challenge::new("tlang-id".to_string(), "tlang".to_string())
+        .with_language("rust".to_string());
+    let mut tracker = StageTracker::new("tlang".to_string());
+    tracker.record(StageInput::Start);
+    tracker.record(StageInput::Keystroke {
+        ch: 't',
+        position: 0,
+    });
+    tracker.record(StageInput::Finish);
+
+    repo.record_session(
+        &session_result,
+        Some(&git_repo),
+        "normal",
+        None,
+        &[("stage1".to_string(), tracker)],
+        &[challenge],
+    )
+    .unwrap();
+
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    let stats = trait_ref.get_language_stats(None).unwrap();
+    assert!(stats.iter().any(|(lang, _, _)| lang == "rust"));
+}
+
+#[test]
+fn test_trait_get_language_stats_empty_when_no_sessions() {
+    let repo = SessionRepository::new().unwrap();
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    let stats = trait_ref.get_language_stats(Some(30)).unwrap();
+    assert!(stats.is_empty());
+}
+
+#[test]
+fn test_trait_get_session_result_for_analytics_returns_recorded_session() {
+    let repo = SessionRepository::new().unwrap();
+
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 222.0;
+    session_result.overall_wpm = 75.0;
+    session_result.overall_accuracy = 97.0;
+    let git_repo = GitRepository {
+        user_name: "tanalyticsuser".to_string(),
+        repository_name: "tanalyticsrepo".to_string(),
+        remote_url: "https://github.com/tanalyticsuser/tanalyticsrepo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("tanalytics1".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    let challenge = Challenge::new("tanalytics-id".to_string(), "tanalytics".to_string());
+    let mut tracker = StageTracker::new("tanalytics".to_string());
+    tracker.record(StageInput::Start);
+    tracker.record(StageInput::Finish);
+
+    let session_id = repo
+        .record_session(
+            &session_result,
+            Some(&git_repo),
+            "normal",
+            None,
+            &[("stage1".to_string(), tracker)],
+            &[challenge],
+        )
+        .unwrap();
+
+    let trait_ref: &dyn SessionRepositoryTrait = &repo;
+    let result = trait_ref
+        .get_session_result_for_analytics(session_id)
+        .unwrap();
+    assert!(result.is_some());
+    let data = result.unwrap();
+    assert_eq!(data.score, 222.0);
+    assert_eq!(data.wpm, 75.0);
+}
+
 // Note: SessionRepository no longer implements HasDatabase trait since database is injected
 
 // Integration tests with actual data

--- a/tests/unit/domain/services/scoring/tracker/stage.rs
+++ b/tests/unit/domain/services/scoring/tracker/stage.rs
@@ -167,3 +167,126 @@ fn test_position_out_of_bounds() {
     assert_eq!(data.keystrokes.len(), 1);
     assert!(!data.keystrokes[0].is_correct);
 }
+
+#[test]
+fn test_finish_while_paused_subtracts_pending_pause() {
+    let mut tracker = StageTracker::new("test".to_string());
+    tracker.record(StageInput::Start);
+    std::thread::sleep(Duration::from_millis(40));
+    tracker.record(StageInput::Pause);
+    std::thread::sleep(Duration::from_millis(80));
+    // Finish while still paused — Finish must close out the pending paused window.
+    tracker.record(StageInput::Finish);
+
+    let data = tracker.get_data();
+    assert!(data.is_finished);
+    // Wall-clock is ~120ms; active time should be ~40ms (well under 100ms).
+    assert!(
+        data.elapsed_time < Duration::from_millis(100),
+        "active time {:?} should exclude the pause that was still open at Finish",
+        data.elapsed_time
+    );
+}
+
+#[test]
+fn test_skip_while_paused_subtracts_pending_pause() {
+    let mut tracker = StageTracker::new("test".to_string());
+    tracker.record(StageInput::Start);
+    std::thread::sleep(Duration::from_millis(40));
+    tracker.record(StageInput::Pause);
+    std::thread::sleep(Duration::from_millis(80));
+    tracker.record(StageInput::Skip);
+
+    let data = tracker.get_data();
+    assert!(data.was_skipped);
+    assert!(data.is_finished);
+    assert!(
+        data.elapsed_time < Duration::from_millis(100),
+        "skip while paused must exclude the pending pause; got {:?}",
+        data.elapsed_time
+    );
+}
+
+#[test]
+fn test_fail_while_paused_subtracts_pending_pause() {
+    let mut tracker = StageTracker::new("test".to_string());
+    tracker.record(StageInput::Start);
+    std::thread::sleep(Duration::from_millis(40));
+    tracker.record(StageInput::Pause);
+    std::thread::sleep(Duration::from_millis(80));
+    tracker.record(StageInput::Fail);
+
+    let data = tracker.get_data();
+    assert!(data.was_failed);
+    assert!(data.is_finished);
+    assert!(
+        data.elapsed_time < Duration::from_millis(100),
+        "fail while paused must exclude the pending pause; got {:?}",
+        data.elapsed_time
+    );
+}
+
+#[test]
+fn test_get_data_while_still_paused_excludes_pause_window() {
+    let mut tracker = StageTracker::new("test".to_string());
+    tracker.record(StageInput::Start);
+    std::thread::sleep(Duration::from_millis(40));
+    tracker.record(StageInput::Pause);
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Observe without finishing — get_data must subtract the in-progress pause.
+    let data = tracker.get_data();
+    assert!(!data.is_finished);
+    assert!(
+        data.elapsed_time < Duration::from_millis(80),
+        "elapsed should track only pre-pause activity; got {:?}",
+        data.elapsed_time
+    );
+}
+
+#[test]
+fn test_pause_is_idempotent_while_already_paused() {
+    let mut tracker = StageTracker::new("test".to_string());
+    tracker.record(StageInput::Start);
+    std::thread::sleep(Duration::from_millis(20));
+    tracker.record(StageInput::Pause);
+    std::thread::sleep(Duration::from_millis(40));
+    // Recording Pause again while already paused must not restart the pause clock.
+    tracker.record(StageInput::Pause);
+    std::thread::sleep(Duration::from_millis(40));
+    tracker.record(StageInput::Resume);
+    tracker.record(StageInput::Finish);
+
+    let data = tracker.get_data();
+    // Active time is ~20ms; total pause is ~80ms regardless of repeat-Pause.
+    assert!(
+        data.elapsed_time < Duration::from_millis(70),
+        "repeat Pause must be a no-op; got {:?}",
+        data.elapsed_time
+    );
+}
+
+#[test]
+fn test_get_data_without_start_returns_zero_elapsed() {
+    let tracker = StageTracker::new("test".to_string());
+    let data = tracker.get_data();
+    assert_eq!(data.elapsed_time, Duration::ZERO);
+    assert!(!data.is_finished);
+}
+
+#[test]
+fn test_set_start_time_overrides_default() {
+    let mut tracker = StageTracker::new("test".to_string());
+    let start = std::time::Instant::now() - Duration::from_millis(200);
+    tracker.set_start_time(start);
+    // Recording Start now must NOT overwrite the manually-set start time.
+    tracker.record(StageInput::Start);
+    tracker.record(StageInput::Finish);
+
+    let data = tracker.get_data();
+    assert!(
+        data.elapsed_time >= Duration::from_millis(190),
+        "expected elapsed ≥ 190ms from manually-set start, got {:?}",
+        data.elapsed_time
+    );
+}

--- a/tests/unit/domain/services/session_manager_service_tests.rs
+++ b/tests/unit/domain/services/session_manager_service_tests.rs
@@ -1002,3 +1002,71 @@ fn test_get_next_challenge_in_progress_with_challenges() {
     let result = manager.get_next_challenge();
     assert!(result.is_ok());
 }
+
+fn create_manager_with_seeded_challenges() -> SessionManager {
+    use gittype::domain::models::Challenge;
+    use gittype::domain::stores::ChallengeStoreInterface;
+
+    let event_bus = Arc::new(EventBus::new()) as Arc<dyn EventBusInterface>;
+    let challenge_store = Arc::new(ChallengeStore::new_for_test());
+    challenge_store.set_challenges(vec![
+        Challenge::new("seed-1".to_string(), "fn foo() {}".to_string()),
+        Challenge::new("seed-2".to_string(), "fn bar() {}".to_string()),
+    ]);
+
+    let repository_store = Arc::new(RepositoryStore::new_for_test());
+    let session_store = Arc::new(SessionStore::new_for_test());
+    let stage_repository = Arc::new(StageRepository::new(
+        None,
+        challenge_store,
+        repository_store,
+        session_store,
+    )) as Arc<dyn StageRepositoryInterface>;
+    let session_tracker =
+        Arc::new(SessionTracker::new_for_test()) as Arc<dyn SessionTrackerInterface>;
+    let total_tracker = Arc::new(TotalTracker::new_for_test()) as Arc<dyn TotalTrackerInterface>;
+
+    SessionManager::new_with_dependencies(
+        event_bus,
+        stage_repository,
+        session_tracker,
+        total_tracker,
+    )
+}
+
+#[test]
+fn test_skip_current_stage_records_session_challenge_when_available() {
+    let manager = create_manager_with_seeded_challenges();
+    manager.reduce(SessionAction::Start).unwrap();
+
+    let mut tracker = StageTracker::new("hello".to_string());
+    tracker.record(StageInput::Start);
+    manager.set_current_stage_tracker(tracker);
+
+    assert!(manager.get_current_challenge().unwrap().is_some());
+
+    let (stage_result, _, needs_new_challenge) = manager.skip_current_stage().unwrap();
+
+    assert!(stage_result.was_skipped);
+    assert!(needs_new_challenge);
+    assert_eq!(manager.get_session_challenges_for_test().len(), 1);
+}
+
+#[test]
+fn test_finalize_current_stage_records_session_challenge_when_available() {
+    let manager = create_manager_with_seeded_challenges();
+    manager.reduce(SessionAction::Start).unwrap();
+
+    let mut tracker = StageTracker::new("hello".to_string());
+    tracker.record(StageInput::Start);
+    for (i, ch) in "hello".chars().enumerate() {
+        tracker.record(StageInput::Keystroke { ch, position: i });
+    }
+    manager.set_current_stage_tracker(tracker);
+
+    let result = manager.finalize_current_stage();
+
+    assert!(result.is_ok());
+    assert_eq!(manager.get_stage_results().len(), 1);
+    assert_eq!(manager.get_session_challenges_for_test().len(), 1);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/c_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/c_tests.rs
@@ -280,3 +280,62 @@ fn extract_name_for_leaf_node_returns_none() {
 
     assert_eq!(name, None);
 }
+
+#[test]
+fn extract_name_for_variable_definition_with_bare_identifier_returns_identifier() {
+    let source = "int counter;\n";
+    let tree = parse_c(source);
+    let decl = find_node(tree.root_node(), "declaration").expect("expected a declaration node");
+
+    let name = CExtractor.extract_name(decl, source, "variable.definition");
+
+    assert_eq!(name.as_deref(), Some("counter"));
+}
+
+#[test]
+fn extract_name_for_variable_definition_on_non_matching_node_returns_none() {
+    let source = "struct Point { int x; int y; };\n";
+    let tree = parse_c(source);
+    let strukt =
+        find_node(tree.root_node(), "struct_specifier").expect("expected a struct_specifier node");
+
+    let name = CExtractor.extract_name(strukt, source, "variable.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_function_definition_without_function_declarator_returns_none() {
+    let source = "struct Point { int x; int y; };\n";
+    let tree = parse_c(source);
+    let strukt =
+        find_node(tree.root_node(), "struct_specifier").expect("expected a struct_specifier node");
+
+    let name = CExtractor.extract_name(strukt, source, "function.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_struct_definition_without_type_identifier_returns_none() {
+    let source = "int add(int a, int b) { return a + b; }\n";
+    let tree = parse_c(source);
+    let func = find_node(tree.root_node(), "function_definition")
+        .expect("expected a function_definition node");
+
+    let name = CExtractor.extract_name(func, source, "struct.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_macro_definition_without_identifier_returns_none() {
+    let source = "struct Point { int x; int y; };\n";
+    let tree = parse_c(source);
+    let strukt =
+        find_node(tree.root_node(), "struct_specifier").expect("expected a struct_specifier node");
+
+    let name = CExtractor.extract_name(strukt, source, "macro.definition");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/c_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/c_tests.rs
@@ -1,6 +1,28 @@
 use gittype::domain::models::ChunkType;
 use gittype::domain::services::source_code_parser::parsers::c::CExtractor;
 use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_c(source: &str) -> tree_sitter::Tree {
+    let mut parser = CExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
+
+fn first_leaf(node: Node<'_>) -> Node<'_> {
+    if node.child_count() == 0 {
+        return node;
+    }
+    first_leaf(node.child(0).unwrap())
+}
 
 #[test]
 fn create_parser_succeeds() {
@@ -129,4 +151,132 @@ fn middle_capture_name_to_chunk_type_code_block() {
 fn middle_capture_name_to_chunk_type_unknown() {
     let extractor = CExtractor;
     assert_eq!(extractor.middle_capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn capture_name_to_chunk_type_type_definition_returns_struct() {
+    assert_eq!(
+        CExtractor.capture_name_to_chunk_type("type.definition"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_enum_definition_returns_struct() {
+    assert_eq!(
+        CExtractor.capture_name_to_chunk_type("enum.definition"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_named_capture_returns_code_block() {
+    let extractor = CExtractor;
+    for name in [
+        "function.name",
+        "struct.name",
+        "type.name",
+        "enum.name",
+        "variable.name",
+        "macro.name",
+    ] {
+        assert_eq!(
+            extractor.capture_name_to_chunk_type(name),
+            Some(ChunkType::CodeBlock),
+            "{} should map to CodeBlock",
+            name
+        );
+    }
+}
+
+#[test]
+fn extract_name_for_function_definition_returns_identifier() {
+    let source = "int add(int a, int b) { return a + b; }\n";
+    let tree = parse_c(source);
+    let func = find_node(tree.root_node(), "function_definition")
+        .expect("expected a function_definition node");
+
+    let name = CExtractor.extract_name(func, source, "function.definition");
+
+    assert_eq!(name.as_deref(), Some("add"));
+}
+
+#[test]
+fn extract_name_for_struct_definition_returns_type_identifier() {
+    let source = "struct Point { int x; int y; };\n";
+    let tree = parse_c(source);
+    let strukt =
+        find_node(tree.root_node(), "struct_specifier").expect("expected a struct_specifier node");
+
+    let name = CExtractor.extract_name(strukt, source, "struct.definition");
+
+    assert_eq!(name.as_deref(), Some("Point"));
+}
+
+#[test]
+fn extract_name_for_type_definition_returns_type_identifier() {
+    let source = "typedef unsigned int MyUInt;\n";
+    let tree = parse_c(source);
+    let typedef =
+        find_node(tree.root_node(), "type_definition").expect("expected a type_definition node");
+
+    let name = CExtractor.extract_name(typedef, source, "type.definition");
+
+    assert_eq!(name.as_deref(), Some("MyUInt"));
+}
+
+#[test]
+fn extract_name_for_enum_definition_returns_type_identifier() {
+    let source = "enum Color { RED, GREEN, BLUE };\n";
+    let tree = parse_c(source);
+    let enm =
+        find_node(tree.root_node(), "enum_specifier").expect("expected an enum_specifier node");
+
+    let name = CExtractor.extract_name(enm, source, "enum.definition");
+
+    assert_eq!(name.as_deref(), Some("Color"));
+}
+
+#[test]
+fn extract_name_for_variable_definition_with_init_returns_identifier() {
+    let source = "int counter = 0;\n";
+    let tree = parse_c(source);
+    let decl = find_node(tree.root_node(), "declaration").expect("expected a declaration node");
+
+    let name = CExtractor.extract_name(decl, source, "variable.definition");
+
+    assert_eq!(name.as_deref(), Some("counter"));
+}
+
+#[test]
+fn extract_name_for_macro_definition_returns_identifier() {
+    let source = "#define MAX_LEN 256\n";
+    let tree = parse_c(source);
+    let macr = find_node(tree.root_node(), "preproc_def").expect("expected a preproc_def node");
+
+    let name = CExtractor.extract_name(macr, source, "macro.definition");
+
+    assert_eq!(name.as_deref(), Some("MAX_LEN"));
+}
+
+#[test]
+fn extract_name_for_unknown_capture_returns_none() {
+    let source = "int x;\n";
+    let tree = parse_c(source);
+    let root = tree.root_node();
+
+    let name = CExtractor.extract_name(root, source, "unknown.capture");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_leaf_node_returns_none() {
+    let source = "42;\n";
+    let tree = parse_c(source);
+    let leaf = first_leaf(tree.root_node());
+
+    let name = CExtractor.extract_name(leaf, source, "function.definition");
+
+    assert_eq!(name, None);
 }

--- a/tests/unit/domain/services/source_code_parser/parsers/clojure_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/clojure_tests.rs
@@ -1,5 +1,21 @@
+use gittype::domain::models::ChunkType;
 use gittype::domain::services::source_code_parser::parsers::clojure::ClojureExtractor;
 use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_clojure(source: &str) -> tree_sitter::Tree {
+    let mut parser = ClojureExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
 
 #[test]
 fn create_parser_succeeds() {
@@ -95,9 +111,6 @@ fn query_uses_match_predicates() {
     let extractor = ClojureExtractor;
     let patterns = extractor.query_patterns();
     let match_count = patterns.matches("#match?").count();
-    // Clojure uses multiple #match? predicates to distinguish different definition types
-    // (defn/defmacro/defn- for Functions, def for Variables, ns for Namespaces,
-    //  deftype/defrecord for Classes, defprotocol for Interfaces)
     assert_eq!(
         match_count, 5,
         "Should use five #match? predicates for different definition types"
@@ -110,4 +123,247 @@ fn query_does_not_use_multiple_eq_predicates() {
     let patterns = extractor.query_patterns();
     let eq_count = patterns.matches("#eq?").count();
     assert_eq!(eq_count, 0, "Should not use #eq? predicates");
+}
+
+// ---------------------------------------------------------------------------
+// capture_name_to_chunk_type — exhaustive enumeration of mapped capture names
+// ---------------------------------------------------------------------------
+
+#[test]
+fn capture_name_to_chunk_type_function_def() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("function_def"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_variable_def() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("variable_def"),
+        Some(ChunkType::Variable)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_namespace_def() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("namespace_def"),
+        Some(ChunkType::Namespace)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_class_def() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("class_def"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_interface_def() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("interface_def"),
+        Some(ChunkType::Interface)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_func_name_returns_code_block() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("func_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_var_name_returns_code_block() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("var_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_ns_name_returns_code_block() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("ns_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_class_name_returns_code_block() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("class_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_interface_name_returns_code_block() {
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("interface_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(ClojureExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn capture_name_to_chunk_type_keyword_captures_return_none() {
+    // The *_keyword capture names are emitted in queries but not mapped — they
+    // should fall through the wildcard arm to None.
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("func_keyword"),
+        None
+    );
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("var_keyword"),
+        None
+    );
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("ns_keyword"),
+        None
+    );
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("class_keyword"),
+        None
+    );
+    assert_eq!(
+        ClojureExtractor.capture_name_to_chunk_type("interface_keyword"),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// middle_capture_name_to_chunk_type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn middle_capture_name_to_chunk_type_expr() {
+    assert_eq!(
+        ClojureExtractor.middle_capture_name_to_chunk_type("expr"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_function_call() {
+    assert_eq!(
+        ClojureExtractor.middle_capture_name_to_chunk_type("function_call"),
+        Some(ChunkType::FunctionCall)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        ClojureExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// extract_name — exercises the recursive walk that finds the 2nd sym_lit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_name_for_defn_returns_function_name() {
+    let source = "(defn hello [x] x)\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "function_def");
+
+    assert_eq!(name.as_deref(), Some("hello"));
+}
+
+#[test]
+fn extract_name_for_def_returns_variable_name() {
+    let source = "(def answer 42)\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "variable_def");
+
+    assert_eq!(name.as_deref(), Some("answer"));
+}
+
+#[test]
+fn extract_name_for_ns_returns_namespace_name() {
+    let source = "(ns my.app.core)\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "namespace_def");
+
+    assert_eq!(name.as_deref(), Some("my.app.core"));
+}
+
+#[test]
+fn extract_name_for_deftype_returns_class_name() {
+    let source = "(deftype Point [x y])\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "class_def");
+
+    assert_eq!(name.as_deref(), Some("Point"));
+}
+
+#[test]
+fn extract_name_for_defprotocol_returns_interface_name() {
+    let source = "(defprotocol Greeter (greet [this]))\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "interface_def");
+
+    assert_eq!(name.as_deref(), Some("Greeter"));
+}
+
+#[test]
+fn extract_name_capture_name_is_ignored() {
+    // extract_clojure_name walks structure regardless of capture_name — pass an
+    // arbitrary string and the result should still be the 2nd sym_lit.
+    let source = "(defn hello [x] x)\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "totally-bogus-capture");
+
+    assert_eq!(name.as_deref(), Some("hello"));
+}
+
+#[test]
+fn extract_name_returns_none_for_list_with_single_sym() {
+    // A list containing only one symbol has no second sym_lit, so the walk
+    // exits without returning a name.
+    let source = "(only-one-symbol)\n";
+    let tree = parse_clojure(source);
+    let list = find_node(tree.root_node(), "list_lit").expect("expected a list_lit node");
+
+    let name = ClojureExtractor.extract_name(list, source, "function_def");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_without_children() {
+    // A bare numeric literal has no child symbols, so goto_first_child returns
+    // false and the function returns None directly.
+    let source = "42\n";
+    let tree = parse_clojure(source);
+    let leaf = find_node(tree.root_node(), "num_lit")
+        .or_else(|| find_node(tree.root_node(), "number_literal"))
+        .expect("expected a numeric leaf node");
+
+    let name = ClojureExtractor.extract_name(leaf, source, "function_def");
+
+    assert_eq!(name, None);
 }

--- a/tests/unit/domain/services/source_code_parser/parsers/cpp_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/cpp_tests.rs
@@ -487,3 +487,72 @@ fn extract_name_for_template_class_definition_returns_type_identifier() {
 
     assert_eq!(name.as_deref(), Some("Holder"));
 }
+
+#[test]
+fn extract_constructor_destructor_name_returns_none_when_no_function_declarator() {
+    let source_code = "struct Empty {};";
+    let tree = parse_cpp(source_code);
+    let struct_node = find_node(
+        tree.root_node(),
+        source_code,
+        "struct_specifier",
+        "struct Empty",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(struct_node, source_code, "constructor.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_operator_name_returns_none_when_no_function_declarator() {
+    let source_code = "struct Empty {};";
+    let tree = parse_cpp(source_code);
+    let struct_node = find_node(
+        tree.root_node(),
+        source_code,
+        "struct_specifier",
+        "struct Empty",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(struct_node, source_code, "operator.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_operator_name_returns_none_when_function_is_not_operator() {
+    let source_code = "int add(int a, int b) { return a + b; }";
+    let tree = parse_cpp(source_code);
+    let function_node =
+        find_node(tree.root_node(), source_code, "function_definition", "add(").unwrap();
+
+    let name = CppExtractor.extract_name(function_node, source_code, "operator.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_type_name_returns_none_when_no_type_identifier_child() {
+    let source_code = "int counter = 0;";
+    let tree = parse_cpp(source_code);
+    let declaration_node =
+        find_node(tree.root_node(), source_code, "declaration", "counter").unwrap();
+
+    let name = CppExtractor.extract_name(declaration_node, source_code, "type.definition");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_function_name_returns_none_when_no_function_declarator() {
+    let source_code = "int x = 5;";
+    let tree = parse_cpp(source_code);
+    let declaration_node = find_node(tree.root_node(), source_code, "declaration", "x").unwrap();
+
+    let name = CppExtractor.extract_name(declaration_node, source_code, "function.definition");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/cpp_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/cpp_tests.rs
@@ -301,3 +301,189 @@ fn extract_name_reads_plain_variable_declarations() {
 
     assert_eq!(name, Some("plain".to_string()));
 }
+
+#[test]
+fn extract_name_for_function_definition_returns_identifier() {
+    let source_code = "int add(int a, int b) { return a + b; }";
+    let tree = parse_cpp(source_code);
+    let function_node =
+        find_node(tree.root_node(), source_code, "function_definition", "add(").unwrap();
+
+    let name = CppExtractor.extract_name(function_node, source_code, "function.definition");
+
+    assert_eq!(name.as_deref(), Some("add"));
+}
+
+#[test]
+fn extract_name_for_method_definition_delegates_to_function_name_extraction() {
+    let source_code = "class Foo { public: void greet() {} };";
+    let tree = parse_cpp(source_code);
+    let definition = find_node(
+        tree.root_node(),
+        source_code,
+        "function_definition",
+        "greet() {}",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(definition, source_code, "method.definition");
+
+    assert_eq!(name.as_deref(), Some("greet"));
+}
+
+#[test]
+fn extract_name_for_class_definition_returns_type_identifier() {
+    let source_code = "class Widget { int x; };";
+    let tree = parse_cpp(source_code);
+    let class_node = find_node(
+        tree.root_node(),
+        source_code,
+        "class_specifier",
+        "class Widget",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(class_node, source_code, "class.definition");
+
+    assert_eq!(name.as_deref(), Some("Widget"));
+}
+
+#[test]
+fn extract_name_for_struct_definition_returns_type_identifier() {
+    let source_code = "struct Point { int x; int y; };";
+    let tree = parse_cpp(source_code);
+    let struct_node = find_node(
+        tree.root_node(),
+        source_code,
+        "struct_specifier",
+        "struct Point",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(struct_node, source_code, "struct.definition");
+
+    assert_eq!(name.as_deref(), Some("Point"));
+}
+
+#[test]
+fn extract_name_for_type_definition_returns_type_identifier() {
+    let source_code = "typedef unsigned int MyUInt;";
+    let tree = parse_cpp(source_code);
+    let typedef_node =
+        find_node(tree.root_node(), source_code, "type_definition", "MyUInt").unwrap();
+
+    let name = CppExtractor.extract_name(typedef_node, source_code, "type.definition");
+
+    assert_eq!(name.as_deref(), Some("MyUInt"));
+}
+
+#[test]
+fn extract_name_for_enum_definition_returns_type_identifier() {
+    let source_code = "enum Color { Red, Green, Blue };";
+    let tree = parse_cpp(source_code);
+    let enum_node = find_node(tree.root_node(), source_code, "enum_specifier", "Color").unwrap();
+
+    let name = CppExtractor.extract_name(enum_node, source_code, "enum.definition");
+
+    assert_eq!(name.as_deref(), Some("Color"));
+}
+
+#[test]
+fn extract_name_for_variable_with_init_returns_identifier() {
+    let source_code = "int counter = 0;";
+    let tree = parse_cpp(source_code);
+    let declaration_node =
+        find_node(tree.root_node(), source_code, "declaration", "counter").unwrap();
+
+    let name = CppExtractor.extract_name(declaration_node, source_code, "variable.definition");
+
+    assert_eq!(name.as_deref(), Some("counter"));
+}
+
+#[test]
+fn extract_name_for_operator_definition_returns_operator_name() {
+    let source_code =
+        "struct Vec { int v; Vec operator+(const Vec& other) const { return Vec{v + other.v}; } };";
+    let tree = parse_cpp(source_code);
+    let operator_node = find_node(
+        tree.root_node(),
+        source_code,
+        "function_definition",
+        "operator+",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(operator_node, source_code, "operator.definition");
+
+    assert!(
+        name.as_deref()
+            .map(|s| s.contains("operator"))
+            .unwrap_or(false),
+        "expected operator name, got {:?}",
+        name
+    );
+}
+
+#[test]
+fn extract_name_for_destructor_definition_returns_tilde_prefixed_name() {
+    let source_code = "class Resource { public: ~Resource() {} };";
+    let tree = parse_cpp(source_code);
+    let destructor_node = find_node(
+        tree.root_node(),
+        source_code,
+        "function_definition",
+        "~Resource",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(destructor_node, source_code, "destructor.definition");
+
+    // destructor_name child structure is parser-dependent; either we get the
+    // tilde-prefixed form or None — both branches in the code are exercised
+    // via this and the constructor test above.
+    assert!(name.is_none() || name.as_deref().unwrap_or("").starts_with('~'));
+}
+
+#[test]
+fn extract_name_for_unknown_capture_returns_none() {
+    let source_code = "int x;";
+    let tree = parse_cpp(source_code);
+
+    let name = CppExtractor.extract_name(tree.root_node(), source_code, "unknown.capture");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_template_function_definition_returns_identifier() {
+    let source_code = "template <typename T> T identity(T value) { return value; }";
+    let tree = parse_cpp(source_code);
+    let definition = find_node(
+        tree.root_node(),
+        source_code,
+        "function_definition",
+        "identity(T value)",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(definition, source_code, "template_function.definition");
+
+    assert_eq!(name.as_deref(), Some("identity"));
+}
+
+#[test]
+fn extract_name_for_template_class_definition_returns_type_identifier() {
+    let source_code = "template <typename T> class Holder { T value; };";
+    let tree = parse_cpp(source_code);
+    let class_node = find_node(
+        tree.root_node(),
+        source_code,
+        "class_specifier",
+        "class Holder",
+    )
+    .unwrap();
+
+    let name = CppExtractor.extract_name(class_node, source_code, "template_class.definition");
+
+    assert_eq!(name.as_deref(), Some("Holder"));
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/csharp_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/csharp_tests.rs
@@ -1,6 +1,21 @@
 use gittype::domain::models::ChunkType;
 use gittype::domain::services::source_code_parser::parsers::csharp::CSharpExtractor;
 use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_csharp(source: &str) -> tree_sitter::Tree {
+    let mut parser = CSharpExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
 
 #[test]
 fn create_parser_succeeds() {
@@ -201,4 +216,88 @@ fn middle_capture_name_code_block() {
 fn middle_capture_name_unknown() {
     let extractor = CSharpExtractor;
     assert_eq!(extractor.middle_capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn extract_name_for_class_returns_identifier() {
+    let source = "class Foo {}\n";
+    let tree = parse_csharp(source);
+    let class_node = find_node(tree.root_node(), "class_declaration")
+        .expect("expected a class_declaration node");
+
+    let name = CSharpExtractor.extract_name(class_node, source, "class");
+
+    assert_eq!(name.as_deref(), Some("Foo"));
+}
+
+#[test]
+fn extract_name_for_method_returns_identifier() {
+    let source = "class Foo { void Greet() {} }\n";
+    let tree = parse_csharp(source);
+    let method_node = find_node(tree.root_node(), "method_declaration")
+        .expect("expected a method_declaration node");
+
+    let name = CSharpExtractor.extract_name(method_node, source, "method");
+
+    assert_eq!(name.as_deref(), Some("Greet"));
+}
+
+#[test]
+fn extract_name_for_field_returns_identifier() {
+    let source = "class Foo { int counter; }\n";
+    let tree = parse_csharp(source);
+    let field_node = find_node(tree.root_node(), "field_declaration")
+        .expect("expected a field_declaration node");
+
+    let name = CSharpExtractor.extract_name(field_node, source, "field");
+
+    assert_eq!(name.as_deref(), Some("counter"));
+}
+
+#[test]
+fn extract_name_for_field_with_initializer_returns_identifier() {
+    let source = "class Foo { string label = \"hi\"; }\n";
+    let tree = parse_csharp(source);
+    let field_node = find_node(tree.root_node(), "field_declaration")
+        .expect("expected a field_declaration node");
+
+    let name = CSharpExtractor.extract_name(field_node, source, "field");
+
+    assert_eq!(name.as_deref(), Some("label"));
+}
+
+#[test]
+fn extract_name_for_namespace_with_simple_identifier_returns_name() {
+    let source = "namespace Foo { class Bar {} }\n";
+    let tree = parse_csharp(source);
+    let ns_node = find_node(tree.root_node(), "namespace_declaration")
+        .expect("expected a namespace_declaration node");
+
+    let name = CSharpExtractor.extract_name(ns_node, source, "namespace");
+
+    assert_eq!(name.as_deref(), Some("Foo"));
+}
+
+#[test]
+fn extract_name_for_namespace_with_qualified_name_returns_full_path() {
+    let source = "namespace Foo.Bar.Baz { class C {} }\n";
+    let tree = parse_csharp(source);
+    let ns_node = find_node(tree.root_node(), "namespace_declaration")
+        .expect("expected a namespace_declaration node");
+
+    let name = CSharpExtractor.extract_name(ns_node, source, "namespace");
+
+    assert_eq!(name.as_deref(), Some("Foo.Bar.Baz"));
+}
+
+#[test]
+fn extract_name_for_unknown_capture_returns_none() {
+    let source = "class Foo {}\n";
+    let tree = parse_csharp(source);
+
+    let name = CSharpExtractor.extract_name(tree.root_node(), source, "unknown.capture");
+
+    // For unknown capture, falls back to extract_name_from_node which searches
+    // for an `identifier` child of root — root has no direct identifier child.
+    assert_eq!(name, None);
 }

--- a/tests/unit/domain/services/source_code_parser/parsers/csharp_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/csharp_tests.rs
@@ -301,3 +301,23 @@ fn extract_name_for_unknown_capture_returns_none() {
     // for an `identifier` child of root — root has no direct identifier child.
     assert_eq!(name, None);
 }
+
+#[test]
+fn extract_name_for_namespace_capture_returns_none_when_no_qualified_or_identifier_child() {
+    let source = "class Foo {}\n";
+    let tree = parse_csharp(source);
+
+    let name = CSharpExtractor.extract_name(tree.root_node(), source, "namespace");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_field_capture_returns_none_when_no_variable_declaration_child() {
+    let source = "class Foo {}\n";
+    let tree = parse_csharp(source);
+
+    let name = CSharpExtractor.extract_name(tree.root_node(), source, "field");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/dart_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/dart_tests.rs
@@ -1,5 +1,21 @@
+use gittype::domain::models::ChunkType;
 use gittype::domain::services::source_code_parser::parsers::dart::DartExtractor;
 use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_dart(source: &str) -> tree_sitter::Tree {
+    let mut parser = DartExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
 
 #[test]
 fn create_parser_succeeds() {
@@ -32,4 +48,171 @@ fn middle_implementation_query_returns_non_empty() {
     let extractor = DartExtractor;
     let query = extractor.middle_implementation_query();
     assert!(!query.is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_function() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("function"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_method() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("method"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_class() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("class"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_enum() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("enum"),
+        Some(ChunkType::Enum)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_mixin_returns_class() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("mixin"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_extension_returns_class() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("extension"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_variable() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("variable"),
+        Some(ChunkType::Variable)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_name_returns_code_block() {
+    assert_eq!(
+        DartExtractor.capture_name_to_chunk_type("name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(DartExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_for_loop_returns_loop() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("for_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_while_loop_returns_loop() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("while_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_if_block_returns_conditional() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("if_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_switch_block_returns_conditional() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("switch_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_try_block_returns_error_handling() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("try_block"),
+        Some(ChunkType::ErrorHandling)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_code_block() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("code_block"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        DartExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_class_declaration_returns_identifier() {
+    let source = "class Foo {}\n";
+    let tree = parse_dart(source);
+    let class =
+        find_node(tree.root_node(), "class_declaration").expect("expected a class_declaration");
+
+    let name = DartExtractor.extract_name(class, source, "class");
+
+    assert_eq!(name.as_deref(), Some("Foo"));
+}
+
+#[test]
+fn extract_name_for_function_declaration_recurses_into_signature() {
+    let source = "void greet() {}\n";
+    let tree = parse_dart(source);
+    let func = find_node(tree.root_node(), "function_signature")
+        .expect("expected a function_signature node");
+
+    let name = DartExtractor.extract_name(func, source, "function");
+
+    assert_eq!(name.as_deref(), Some("greet"));
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_node() {
+    let source = "1\n";
+    let tree = parse_dart(source);
+
+    fn first_leaf<'tree>(node: Node<'tree>) -> Node<'tree> {
+        if node.child_count() == 0 {
+            return node;
+        }
+        first_leaf(node.child(0).unwrap())
+    }
+
+    let leaf = first_leaf(tree.root_node());
+    let name = DartExtractor.extract_name(leaf, source, "function");
+
+    assert_eq!(name, None);
 }

--- a/tests/unit/domain/services/source_code_parser/parsers/dart_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/dart_tests.rs
@@ -216,3 +216,32 @@ fn extract_name_returns_none_for_leaf_node() {
 
     assert_eq!(name, None);
 }
+
+#[test]
+fn extract_name_recurses_into_function_signature_child() {
+    let source = "void greet() {}\n";
+    let tree = parse_dart(source);
+    let func_decl = find_node(tree.root_node(), "function_declaration")
+        .expect("expected a function_declaration node");
+    assert!(func_decl
+        .child(0)
+        .map(|child| child.kind() != "identifier")
+        .unwrap_or(false));
+
+    let name = DartExtractor.extract_name(func_decl, source, "function");
+
+    assert_eq!(name.as_deref(), Some("greet"));
+}
+
+#[test]
+fn extract_name_recurses_into_initialized_variable_definition_child() {
+    let source = "void main() { int counter = 5; }\n";
+    let tree = parse_dart(source);
+    let local_decl = find_node(tree.root_node(), "local_variable_declaration")
+        .or_else(|| find_node(tree.root_node(), "initialized_variable_definition"))
+        .expect("expected a variable declaration node");
+
+    let name = DartExtractor.extract_name(local_decl, source, "variable");
+
+    assert_eq!(name.as_deref(), Some("counter"));
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/elixir_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/elixir_tests.rs
@@ -1,0 +1,228 @@
+use gittype::domain::models::ChunkType;
+use gittype::domain::services::source_code_parser::parsers::elixir::ElixirExtractor;
+use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_elixir(source: &str) -> tree_sitter::Tree {
+    let mut parser = ElixirExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
+
+#[test]
+fn create_parser_succeeds() {
+    let result = ElixirExtractor::create_parser();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn tree_sitter_language_returns_language() {
+    let extractor = ElixirExtractor;
+    let _language = extractor.tree_sitter_language();
+}
+
+#[test]
+fn query_patterns_returns_non_empty() {
+    let extractor = ElixirExtractor;
+    assert!(!extractor.query_patterns().is_empty());
+}
+
+#[test]
+fn comment_query_returns_non_empty() {
+    let extractor = ElixirExtractor;
+    assert!(!extractor.comment_query().is_empty());
+}
+
+#[test]
+fn middle_implementation_query_returns_non_empty() {
+    let extractor = ElixirExtractor;
+    assert!(!extractor.middle_implementation_query().is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_function() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("function"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_module() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("module"),
+        Some(ChunkType::Module)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_macro_def() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("macro_def"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_protocol() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("protocol"),
+        Some(ChunkType::Interface)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_impl_def() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("impl_def"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_struct_def() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("struct_def"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_guard_def() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("guard_def"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_func_name_returns_code_block() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("func_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_module_name_returns_code_block() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("module_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_macro_name_returns_code_block() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("macro_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_protocol_name_returns_code_block() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("protocol_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_guard_name_returns_code_block() {
+    assert_eq!(
+        ElixirExtractor.capture_name_to_chunk_type("guard_name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(ElixirExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_control_flow() {
+    assert_eq!(
+        ElixirExtractor.middle_capture_name_to_chunk_type("control_flow"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_function_call() {
+    assert_eq!(
+        ElixirExtractor.middle_capture_name_to_chunk_type("function_call"),
+        Some(ChunkType::FunctionCall)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_anonymous_fn() {
+    assert_eq!(
+        ElixirExtractor.middle_capture_name_to_chunk_type("anonymous_fn"),
+        Some(ChunkType::Lambda)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        ElixirExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_call_returns_target_identifier() {
+    let source = "defmodule Foo do\nend\n";
+    let tree = parse_elixir(source);
+    let call = find_node(tree.root_node(), "call").expect("expected a call node");
+
+    let name = ElixirExtractor.extract_name(call, source, "module");
+
+    assert_eq!(name.as_deref(), Some("defmodule"));
+}
+
+#[test]
+fn extract_name_for_arguments_with_alias_returns_alias_text() {
+    let source = "defmodule Foo do\nend\n";
+    let tree = parse_elixir(source);
+    let arguments = find_node(tree.root_node(), "arguments").expect("expected an arguments node");
+
+    let name = ElixirExtractor.extract_name(arguments, source, "module_name");
+
+    assert_eq!(name.as_deref(), Some("Foo"));
+}
+
+#[test]
+fn extract_name_walks_siblings_when_no_identifier_or_alias_present() {
+    let source = "def hello(name), do: name\n";
+    let tree = parse_elixir(source);
+    let arguments = find_node(tree.root_node(), "arguments").expect("expected an arguments node");
+
+    let name = ElixirExtractor.extract_name(arguments, source, "func_name");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_node_without_children() {
+    let source = "1\n";
+    let tree = parse_elixir(source);
+    let leaf = find_node(tree.root_node(), "integer")
+        .or_else(|| find_node(tree.root_node(), "integer_literal"))
+        .or_else(|| find_node(tree.root_node(), "number"))
+        .expect("expected a numeric leaf node");
+
+    let name = ElixirExtractor.extract_name(leaf, source, "function");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/elixir_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/elixir_tests.rs
@@ -226,3 +226,25 @@ fn extract_name_returns_none_for_leaf_node_without_children() {
 
     assert_eq!(name, None);
 }
+
+#[test]
+fn extract_name_for_dot_target_call_returns_first_argument_identifier() {
+    let source = "Foo.bar(x)\n";
+    let tree = parse_elixir(source);
+    let call = find_node(tree.root_node(), "call").expect("expected a call node");
+
+    let name = ElixirExtractor.extract_name(call, source, "function_call");
+
+    assert_eq!(name.as_deref(), Some("x"));
+}
+
+#[test]
+fn extract_name_for_dot_target_call_with_no_identifier_args_returns_none() {
+    let source = "Foo.bar(:atom)\n";
+    let tree = parse_elixir(source);
+    let call = find_node(tree.root_node(), "call").expect("expected a call node");
+
+    let name = ElixirExtractor.extract_name(call, source, "function_call");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/erlang_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/erlang_tests.rs
@@ -1,0 +1,234 @@
+use gittype::domain::models::ChunkType;
+use gittype::domain::services::source_code_parser::parsers::erlang::ErlangExtractor;
+use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_erlang(source: &str) -> tree_sitter::Tree {
+    let mut parser = ErlangExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
+
+#[test]
+fn create_parser_succeeds() {
+    let result = ErlangExtractor::create_parser();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn tree_sitter_language_returns_language() {
+    let extractor = ErlangExtractor;
+    let _language = extractor.tree_sitter_language();
+}
+
+#[test]
+fn query_patterns_returns_non_empty() {
+    let extractor = ErlangExtractor;
+    assert!(!extractor.query_patterns().is_empty());
+}
+
+#[test]
+fn comment_query_returns_non_empty() {
+    let extractor = ErlangExtractor;
+    assert!(!extractor.comment_query().is_empty());
+}
+
+#[test]
+fn middle_implementation_query_returns_non_empty() {
+    let extractor = ErlangExtractor;
+    assert!(!extractor.middle_implementation_query().is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_function() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("function"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_module_attr() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("module_attr"),
+        Some(ChunkType::Module)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_export_attr() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("export_attr"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_record_decl() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("record_decl"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_type_alias() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("type_alias"),
+        Some(ChunkType::TypeAlias)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_spec_decl() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("spec_decl"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_behaviour_attr() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("behaviour_attr"),
+        Some(ChunkType::Interface)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_func_name_returns_none() {
+    assert_eq!(
+        ErlangExtractor.capture_name_to_chunk_type("func_name"),
+        None
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(ErlangExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_case_expr() {
+    assert_eq!(
+        ErlangExtractor.middle_capture_name_to_chunk_type("case_expr"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_if_expr() {
+    assert_eq!(
+        ErlangExtractor.middle_capture_name_to_chunk_type("if_expr"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_receive_expr() {
+    assert_eq!(
+        ErlangExtractor.middle_capture_name_to_chunk_type("receive_expr"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_try_expr() {
+    assert_eq!(
+        ErlangExtractor.middle_capture_name_to_chunk_type("try_expr"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_anonymous_fn() {
+    assert_eq!(
+        ErlangExtractor.middle_capture_name_to_chunk_type("anonymous_fn"),
+        Some(ChunkType::Lambda)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        ErlangExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_function_returns_function_atom() {
+    let source = "-module(m).\nhello(Name) -> Name.\n";
+    let tree = parse_erlang(source);
+    let func = find_node(tree.root_node(), "fun_decl").expect("expected a fun_decl node");
+
+    let name = ErlangExtractor.extract_name(func, source, "function");
+
+    assert_eq!(name.as_deref(), Some("hello"));
+}
+
+#[test]
+fn extract_name_for_module_attr_returns_module_atom() {
+    let source = "-module(greeter).\n";
+    let tree = parse_erlang(source);
+    let module_attr =
+        find_node(tree.root_node(), "module_attribute").expect("expected a module_attribute node");
+
+    let name = ErlangExtractor.extract_name(module_attr, source, "module_attr");
+
+    assert_eq!(name.as_deref(), Some("greeter"));
+}
+
+#[test]
+fn extract_name_for_record_decl_returns_record_atom() {
+    let source = "-module(m).\n-record(user, {name, email}).\n";
+    let tree = parse_erlang(source);
+    let record = find_node(tree.root_node(), "record_decl").expect("expected a record_decl node");
+
+    let name = ErlangExtractor.extract_name(record, source, "record_decl");
+
+    assert_eq!(name.as_deref(), Some("user"));
+}
+
+#[test]
+fn extract_name_for_behaviour_attr_returns_behaviour_atom() {
+    let source = "-module(m).\n-behaviour(gen_server).\n";
+    let tree = parse_erlang(source);
+    let behaviour = find_node(tree.root_node(), "behaviour_attribute")
+        .expect("expected a behaviour_attribute node");
+
+    let name = ErlangExtractor.extract_name(behaviour, source, "behaviour_attr");
+
+    assert_eq!(name.as_deref(), Some("gen_server"));
+}
+
+#[test]
+fn extract_name_for_unknown_capture_returns_node_text() {
+    let source = "-module(m).\n";
+    let tree = parse_erlang(source);
+    let module_attr =
+        find_node(tree.root_node(), "module_attribute").expect("expected a module_attribute node");
+
+    let name = ErlangExtractor.extract_name(module_attr, source, "unknown_capture");
+
+    assert_eq!(name.as_deref(), Some("-module(m)."));
+}
+
+#[test]
+fn extract_atom_child_returns_none_when_no_atom_present() {
+    let source = "1.\n";
+    let tree = parse_erlang(source);
+    let root = tree.root_node();
+
+    let name = ErlangExtractor.extract_name(root, source, "module_attr");
+
+    assert!(name.is_none());
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/java_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/java_tests.rs
@@ -1,5 +1,21 @@
+use gittype::domain::models::ChunkType;
 use gittype::domain::services::source_code_parser::parsers::java::JavaExtractor;
 use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_java(source: &str) -> tree_sitter::Tree {
+    let mut parser = JavaExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
 
 #[test]
 fn create_parser_succeeds() {
@@ -32,4 +48,227 @@ fn middle_implementation_query_returns_non_empty() {
     let extractor = JavaExtractor;
     let query = extractor.middle_implementation_query();
     assert!(!query.is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_class() {
+    assert_eq!(
+        JavaExtractor.capture_name_to_chunk_type("class"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_interface() {
+    assert_eq!(
+        JavaExtractor.capture_name_to_chunk_type("interface"),
+        Some(ChunkType::Interface)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_method() {
+    assert_eq!(
+        JavaExtractor.capture_name_to_chunk_type("method"),
+        Some(ChunkType::Method)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_enum() {
+    assert_eq!(
+        JavaExtractor.capture_name_to_chunk_type("enum"),
+        Some(ChunkType::Enum)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_field_returns_variable() {
+    assert_eq!(
+        JavaExtractor.capture_name_to_chunk_type("field"),
+        Some(ChunkType::Variable)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_name_returns_code_block() {
+    assert_eq!(
+        JavaExtractor.capture_name_to_chunk_type("name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(JavaExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_for_loop_returns_loop() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("for_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_enhanced_for_returns_loop() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("enhanced_for"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_while_loop_returns_loop() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("while_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_if_block_returns_conditional() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("if_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_try_block_returns_error_handling() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("try_block"),
+        Some(ChunkType::ErrorHandling)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_switch_block_returns_conditional() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("switch_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_method_call_returns_function_call() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("method_call"),
+        Some(ChunkType::FunctionCall)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_lambda_returns_lambda() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("lambda"),
+        Some(ChunkType::Lambda)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_code_block_returns_code_block() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("code_block"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        JavaExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_class_declaration_returns_identifier() {
+    let source = "class Foo {}\n";
+    let tree = parse_java(source);
+    let class =
+        find_node(tree.root_node(), "class_declaration").expect("expected a class_declaration");
+
+    let name = JavaExtractor.extract_name(class, source, "class");
+
+    assert_eq!(name.as_deref(), Some("Foo"));
+}
+
+#[test]
+fn extract_name_for_interface_declaration_returns_identifier() {
+    let source = "interface Bar {}\n";
+    let tree = parse_java(source);
+    let iface = find_node(tree.root_node(), "interface_declaration")
+        .expect("expected an interface_declaration");
+
+    let name = JavaExtractor.extract_name(iface, source, "interface");
+
+    assert_eq!(name.as_deref(), Some("Bar"));
+}
+
+#[test]
+fn extract_name_for_method_declaration_returns_identifier() {
+    let source = "class Foo { void greet() {} }\n";
+    let tree = parse_java(source);
+    let method =
+        find_node(tree.root_node(), "method_declaration").expect("expected a method_declaration");
+
+    let name = JavaExtractor.extract_name(method, source, "method");
+
+    assert_eq!(name.as_deref(), Some("greet"));
+}
+
+#[test]
+fn extract_name_for_enum_declaration_returns_identifier() {
+    let source = "enum Color { RED, GREEN }\n";
+    let tree = parse_java(source);
+    let enum_node =
+        find_node(tree.root_node(), "enum_declaration").expect("expected an enum_declaration");
+
+    let name = JavaExtractor.extract_name(enum_node, source, "enum");
+
+    assert_eq!(name.as_deref(), Some("Color"));
+}
+
+#[test]
+fn extract_name_for_field_declaration_returns_variable_name() {
+    let source = "class Foo { int counter = 0; }\n";
+    let tree = parse_java(source);
+    let field =
+        find_node(tree.root_node(), "field_declaration").expect("expected a field_declaration");
+
+    let name = JavaExtractor.extract_name(field, source, "field");
+
+    assert_eq!(name.as_deref(), Some("counter"));
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_node() {
+    let source = "1\n";
+    let tree = parse_java(source);
+
+    fn first_leaf<'tree>(node: Node<'tree>) -> Node<'tree> {
+        if node.child_count() == 0 {
+            return node;
+        }
+        first_leaf(node.child(0).unwrap())
+    }
+
+    let leaf = first_leaf(tree.root_node());
+    let name = JavaExtractor.extract_name(leaf, source, "method");
+
+    assert_eq!(name, None);
+}
+
+#[test]
+fn extract_name_for_field_capture_on_node_without_variable_declarator_returns_none() {
+    let source = "class Foo { void greet() {} }\n";
+    let tree = parse_java(source);
+    let method =
+        find_node(tree.root_node(), "method_declaration").expect("expected a method_declaration");
+
+    let name = JavaExtractor.extract_name(method, source, "field");
+
+    assert_eq!(name, None);
 }

--- a/tests/unit/domain/services/source_code_parser/parsers/javascript_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/javascript_tests.rs
@@ -187,6 +187,37 @@ fn extract_name_reads_self_closing_jsx_component_name() {
     );
 }
 
+#[test]
+fn extract_name_returns_none_when_variable_declarator_uses_destructuring() {
+    let extractor = JavaScriptExtractor;
+    let source = "const { value } = source;";
+    let tree = JavaScriptExtractor::create_parser()
+        .unwrap()
+        .parse(source, None)
+        .unwrap();
+    let declarator = find_node(tree.root_node(), "variable_declarator").unwrap();
+
+    assert_eq!(
+        extractor.extract_name(declarator, source, "arrow_function"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_returns_none_for_jsx_capture_when_node_has_no_identifier_child() {
+    let extractor = JavaScriptExtractor;
+    let source = "const value = 1;";
+    let tree = JavaScriptExtractor::create_parser()
+        .unwrap()
+        .parse(source, None)
+        .unwrap();
+
+    assert_eq!(
+        extractor.extract_name(tree.root_node(), source, "jsx_element"),
+        None
+    );
+}
+
 fn find_node<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
     (node.kind() == kind).then_some(node).or_else(|| {
         let mut cursor = node.walk();

--- a/tests/unit/domain/services/source_code_parser/parsers/kotlin_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/kotlin_tests.rs
@@ -1,5 +1,21 @@
+use gittype::domain::models::ChunkType;
 use gittype::domain::services::source_code_parser::parsers::kotlin::KotlinExtractor;
 use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_kotlin(source: &str) -> tree_sitter::Tree {
+    let mut parser = KotlinExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
 
 #[test]
 fn create_parser_succeeds() {
@@ -32,4 +48,190 @@ fn middle_implementation_query_returns_non_empty() {
     let extractor = KotlinExtractor;
     let query = extractor.middle_implementation_query();
     assert!(!query.is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_function() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("function"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_class() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("class"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_interface() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("interface"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_object() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("object"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_companion() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("companion"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_property() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("property"),
+        Some(ChunkType::Variable)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_enum_entry() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("enum_entry"),
+        Some(ChunkType::Const)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_type_alias() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("type_alias"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_lambda() {
+    assert_eq!(
+        KotlinExtractor.capture_name_to_chunk_type("lambda"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(KotlinExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_for_loop() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("for_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_while_loop() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("while_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_if_block() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("if_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_when_block() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("when_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_try_block() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("try_block"),
+        Some(ChunkType::ErrorHandling)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_function_call() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("function_call"),
+        Some(ChunkType::FunctionCall)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_lambda() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("lambda"),
+        Some(ChunkType::Lambda)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        KotlinExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_companion_returns_hardcoded_string() {
+    let source = "val x = 1";
+    let tree = parse_kotlin(source);
+
+    let name = KotlinExtractor.extract_name(tree.root_node(), source, "companion");
+
+    assert_eq!(name, Some("companion object".to_string()));
+}
+
+#[test]
+fn extract_name_for_property_walks_variable_declaration() {
+    let source = "val myVar: Int = 42";
+    let tree = parse_kotlin(source);
+    let property = find_node(tree.root_node(), "property_declaration").unwrap();
+
+    let name = KotlinExtractor.extract_name(property, source, "property");
+
+    assert!(name.is_none() || name.as_deref() == Some("myVar"));
+}
+
+#[test]
+fn extract_name_for_other_capture_walks_node_children() {
+    let source = "fun greet(): Int = 1";
+    let tree = parse_kotlin(source);
+    let function = find_node(tree.root_node(), "function_declaration").unwrap();
+
+    let name = KotlinExtractor.extract_name(function, source, "function");
+
+    assert!(name.is_none() || name.as_deref() == Some("greet"));
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_node_without_children() {
+    let source = "val x = 1";
+    let tree = parse_kotlin(source);
+    let leaf = find_node(tree.root_node(), "number_literal")
+        .or_else(|| find_node(tree.root_node(), "integer_literal"))
+        .expect("expected a literal leaf node");
+
+    let name = KotlinExtractor.extract_name(leaf, source, "function");
+
+    assert_eq!(name, None);
 }

--- a/tests/unit/domain/services/source_code_parser/parsers/mod.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/mod.rs
@@ -3,6 +3,7 @@ mod clojure_tests;
 mod cpp_tests;
 mod csharp_tests;
 mod dart_tests;
+mod elixir_tests;
 mod erlang_tests;
 mod go_tests;
 mod haskell_tests;

--- a/tests/unit/domain/services/source_code_parser/parsers/mod.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/mod.rs
@@ -3,6 +3,7 @@ mod clojure_tests;
 mod cpp_tests;
 mod csharp_tests;
 mod dart_tests;
+mod erlang_tests;
 mod go_tests;
 mod haskell_tests;
 mod java_tests;

--- a/tests/unit/domain/services/source_code_parser/parsers/mod.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/mod.rs
@@ -16,4 +16,6 @@ mod python_tests;
 mod ruby_tests;
 mod rust_tests;
 mod scala_tests;
+mod swift_tests;
 mod typescript_tests;
+mod zig_tests;

--- a/tests/unit/domain/services/source_code_parser/parsers/swift_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/swift_tests.rs
@@ -1,0 +1,224 @@
+use gittype::domain::models::ChunkType;
+use gittype::domain::services::source_code_parser::parsers::swift::SwiftExtractor;
+use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_swift(source: &str) -> tree_sitter::Tree {
+    let mut parser = SwiftExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
+
+#[test]
+fn create_parser_succeeds() {
+    let result = SwiftExtractor::create_parser();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn tree_sitter_language_returns_language() {
+    let extractor = SwiftExtractor;
+    let _language = extractor.tree_sitter_language();
+}
+
+#[test]
+fn query_patterns_returns_non_empty() {
+    let extractor = SwiftExtractor;
+    assert!(!extractor.query_patterns().is_empty());
+}
+
+#[test]
+fn comment_query_returns_non_empty() {
+    let extractor = SwiftExtractor;
+    assert!(!extractor.comment_query().is_empty());
+}
+
+#[test]
+fn middle_implementation_query_returns_non_empty() {
+    let extractor = SwiftExtractor;
+    assert!(!extractor.middle_implementation_query().is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_function() {
+    assert_eq!(
+        SwiftExtractor.capture_name_to_chunk_type("function"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_class() {
+    assert_eq!(
+        SwiftExtractor.capture_name_to_chunk_type("class"),
+        Some(ChunkType::Class)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_struct() {
+    assert_eq!(
+        SwiftExtractor.capture_name_to_chunk_type("struct"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_enum() {
+    assert_eq!(
+        SwiftExtractor.capture_name_to_chunk_type("enum"),
+        Some(ChunkType::Enum)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_protocol_returns_interface() {
+    assert_eq!(
+        SwiftExtractor.capture_name_to_chunk_type("protocol"),
+        Some(ChunkType::Interface)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_name_returns_code_block() {
+    assert_eq!(
+        SwiftExtractor.capture_name_to_chunk_type("name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(SwiftExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_for_loop_returns_loop() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("for_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_while_loop_returns_loop() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("while_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_if_block_returns_conditional() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("if_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_switch_block_returns_conditional() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("switch_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_do_block_returns_special_block() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("do_block"),
+        Some(ChunkType::SpecialBlock)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_guard_block_returns_special_block() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("guard_block"),
+        Some(ChunkType::SpecialBlock)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_function_call_returns_function_call() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("function_call"),
+        Some(ChunkType::FunctionCall)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_closure_returns_lambda() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("closure"),
+        Some(ChunkType::Lambda)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_code_block() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("code_block"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        SwiftExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_function_declaration_returns_identifier() {
+    let source = "func greet() {}\n";
+    let tree = parse_swift(source);
+    let function = find_node(tree.root_node(), "function_declaration")
+        .expect("expected a function_declaration node");
+
+    let name = SwiftExtractor.extract_name(function, source, "function");
+
+    assert_eq!(name.as_deref(), Some("greet"));
+}
+
+#[test]
+fn extract_name_for_class_declaration_returns_type_identifier() {
+    let source = "class Foo {}\n";
+    let tree = parse_swift(source);
+    let class =
+        find_node(tree.root_node(), "class_declaration").expect("expected a class_declaration");
+
+    let name = SwiftExtractor.extract_name(class, source, "class");
+
+    assert_eq!(name.as_deref(), Some("Foo"));
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_node() {
+    let source = "1\n";
+    let tree = parse_swift(source);
+    let root = tree.root_node();
+
+    fn first_leaf<'tree>(node: Node<'tree>) -> Node<'tree> {
+        if node.child_count() == 0 {
+            return node;
+        }
+        first_leaf(node.child(0).unwrap())
+    }
+
+    let leaf = first_leaf(root);
+    let name = SwiftExtractor.extract_name(leaf, source, "function");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/source_code_parser/parsers/zig_tests.rs
+++ b/tests/unit/domain/services/source_code_parser/parsers/zig_tests.rs
@@ -1,0 +1,171 @@
+use gittype::domain::models::ChunkType;
+use gittype::domain::services::source_code_parser::parsers::zig::ZigExtractor;
+use gittype::domain::services::source_code_parser::parsers::LanguageExtractor;
+use tree_sitter::Node;
+
+fn parse_zig(source: &str) -> tree_sitter::Tree {
+    let mut parser = ZigExtractor::create_parser().unwrap();
+    parser.parse(source, None).unwrap()
+}
+
+fn find_node<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .find_map(|child| find_node(child, kind))
+}
+
+#[test]
+fn create_parser_succeeds() {
+    let result = ZigExtractor::create_parser();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn tree_sitter_language_returns_language() {
+    let extractor = ZigExtractor;
+    let _language = extractor.tree_sitter_language();
+}
+
+#[test]
+fn query_patterns_returns_non_empty() {
+    let extractor = ZigExtractor;
+    assert!(!extractor.query_patterns().is_empty());
+}
+
+#[test]
+fn comment_query_returns_non_empty() {
+    let extractor = ZigExtractor;
+    assert!(!extractor.comment_query().is_empty());
+}
+
+#[test]
+fn middle_implementation_query_returns_non_empty() {
+    let extractor = ZigExtractor;
+    assert!(!extractor.middle_implementation_query().is_empty());
+}
+
+#[test]
+fn capture_name_to_chunk_type_function() {
+    assert_eq!(
+        ZigExtractor.capture_name_to_chunk_type("function"),
+        Some(ChunkType::Function)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_struct() {
+    assert_eq!(
+        ZigExtractor.capture_name_to_chunk_type("struct"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_enum() {
+    assert_eq!(
+        ZigExtractor.capture_name_to_chunk_type("enum"),
+        Some(ChunkType::Enum)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_union_returns_struct() {
+    assert_eq!(
+        ZigExtractor.capture_name_to_chunk_type("union"),
+        Some(ChunkType::Struct)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_name_returns_code_block() {
+    assert_eq!(
+        ZigExtractor.capture_name_to_chunk_type("name"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(ZigExtractor.capture_name_to_chunk_type("unknown"), None);
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_for_loop_returns_loop() {
+    assert_eq!(
+        ZigExtractor.middle_capture_name_to_chunk_type("for_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_while_loop_returns_loop() {
+    assert_eq!(
+        ZigExtractor.middle_capture_name_to_chunk_type("while_loop"),
+        Some(ChunkType::Loop)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_if_block_returns_conditional() {
+    assert_eq!(
+        ZigExtractor.middle_capture_name_to_chunk_type("if_block"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_switch_expr_returns_conditional() {
+    assert_eq!(
+        ZigExtractor.middle_capture_name_to_chunk_type("switch_expr"),
+        Some(ChunkType::Conditional)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_code_block() {
+    assert_eq!(
+        ZigExtractor.middle_capture_name_to_chunk_type("code_block"),
+        Some(ChunkType::CodeBlock)
+    );
+}
+
+#[test]
+fn middle_capture_name_to_chunk_type_unknown_returns_none() {
+    assert_eq!(
+        ZigExtractor.middle_capture_name_to_chunk_type("unknown"),
+        None
+    );
+}
+
+#[test]
+fn extract_name_for_function_declaration_returns_identifier() {
+    let source = "fn greet() void {}\n";
+    let tree = parse_zig(source);
+    let function = find_node(tree.root_node(), "function_declaration")
+        .expect("expected a function_declaration node");
+
+    let name = ZigExtractor.extract_name(function, source, "function");
+
+    assert_eq!(name.as_deref(), Some("greet"));
+}
+
+#[test]
+fn extract_name_returns_none_for_leaf_identifier() {
+    let source = "x\n";
+    let tree = parse_zig(source);
+
+    fn first_leaf<'tree>(node: Node<'tree>) -> Node<'tree> {
+        if node.child_count() == 0 {
+            return node;
+        }
+        first_leaf(node.child(0).unwrap())
+    }
+
+    let leaf = first_leaf(tree.root_node());
+    let name = ZigExtractor.extract_name(leaf, source, "function");
+
+    assert_eq!(name, None);
+}

--- a/tests/unit/domain/services/theme_manager_tests.rs
+++ b/tests/unit/domain/services/theme_manager_tests.rs
@@ -223,3 +223,16 @@ fn ascii_theme_uses_ascii_language_colors() {
         let _ = color;
     }
 }
+
+#[test]
+fn get_color_for_language_picks_ascii_key_when_current_theme_is_ascii() {
+    let ascii_theme = Theme::all_themes()
+        .into_iter()
+        .find(|t| t.id == "ascii")
+        .expect("ascii theme exists");
+    let manager = ThemeService::new_for_test(ascii_theme, ColorMode::Dark);
+
+    let color = manager.get_color_for_language("rust");
+
+    assert_eq!(color, ratatui::style::Color::White);
+}

--- a/tests/unit/infrastructure/database/daos/repository_dao_tests.rs
+++ b/tests/unit/infrastructure/database/daos/repository_dao_tests.rs
@@ -1,5 +1,9 @@
-use gittype::domain::models::GitRepository;
-use gittype::infrastructure::database::daos::{RepositoryDao, RepositoryDaoInterface};
+use gittype::domain::models::storage::SaveSessionResultParams;
+use gittype::domain::models::{Challenge, GitRepository, SessionResult};
+use gittype::infrastructure::database::daos::{
+    ChallengeDao, ChallengeDaoInterface, RepositoryDao, RepositoryDaoInterface, SessionDao,
+    SessionDaoInterface,
+};
 use gittype::infrastructure::database::database::{Database, DatabaseInterface};
 use std::sync::Arc;
 
@@ -278,6 +282,221 @@ fn test_get_all_repositories_with_languages() {
         0,
         "Languages should be empty without sessions"
     );
+}
+
+fn insert_stage_result_with_language(
+    db: &Arc<dyn DatabaseInterface>,
+    repository_id: i64,
+    language: &str,
+    challenge_id: &str,
+) {
+    let session_dao = SessionDao::new(Arc::clone(db));
+    let challenge_dao = ChallengeDao::new(Arc::clone(db));
+    let git_repo = GitRepository {
+        user_name: "languser".to_string(),
+        repository_name: "langrepo".to_string(),
+        remote_url: "https://github.com/languser/langrepo".to_string(),
+        branch: Some("main".to_string()),
+        commit_hash: Some("abc".to_string()),
+        is_dirty: false,
+        root_path: None,
+    };
+    let session_result = SessionResult::new();
+
+    let challenge = Challenge::new(challenge_id.to_string(), "fn dummy() {}".to_string())
+        .with_language(language.to_string());
+
+    let conn = db.get_connection().unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    challenge_dao
+        .ensure_challenge_in_transaction(&tx, &challenge)
+        .unwrap();
+    let session_id = session_dao
+        .create_session_in_transaction(
+            &tx,
+            Some(repository_id),
+            &session_result,
+            Some(&git_repo),
+            "normal",
+            Some("easy"),
+        )
+        .unwrap();
+    session_dao
+        .save_session_result_in_transaction(
+            &tx,
+            SaveSessionResultParams {
+                session_id,
+                repository_id: Some(repository_id),
+                session_result: &session_result,
+                stage_engines: &[],
+                game_mode: "normal",
+                difficulty_level: Some("easy"),
+            },
+        )
+        .unwrap();
+
+    let completed_at = chrono::Utc::now().to_rfc3339();
+    tx.execute(
+        "INSERT INTO stages (session_id, challenge_id, stage_number, started_at, completed_at)
+         VALUES (?, ?, ?, ?, ?)",
+        rusqlite::params![session_id, challenge_id, 1i64, &completed_at, &completed_at],
+    )
+    .unwrap();
+    let stage_id = tx.last_insert_rowid();
+
+    tx.execute(
+        "INSERT INTO stage_results (
+            stage_id, session_id, repository_id, keystrokes, mistakes, duration_ms,
+            wpm, cpm, accuracy, consistency_streaks, score, rank_name, tier_name,
+            rank_position, rank_total, position, total,
+            was_skipped, was_failed, completed_at, language, difficulty_level
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rusqlite::params![
+            stage_id,
+            session_id,
+            repository_id,
+            10i64,
+            0i64,
+            1000i64,
+            50.0,
+            250.0,
+            100.0,
+            "[]",
+            50.0,
+            "Beginner",
+            "Bronze",
+            1i64,
+            100i64,
+            1i64,
+            500i64,
+            false,
+            false,
+            &completed_at,
+            language,
+            "Easy",
+        ],
+    )
+    .unwrap();
+
+    tx.commit().unwrap();
+}
+
+#[test]
+fn test_get_all_repositories_with_languages_aggregates_multiple_languages() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let dao = RepositoryDao::new(Arc::clone(&db));
+
+    let git_repo = GitRepository {
+        user_name: "languser".to_string(),
+        repository_name: "langrepo".to_string(),
+        remote_url: "https://github.com/languser/langrepo".to_string(),
+        branch: None,
+        commit_hash: None,
+        is_dirty: false,
+        root_path: None,
+    };
+    let repository_id = dao.ensure_repository(&git_repo).unwrap();
+
+    insert_stage_result_with_language(&db, repository_id, "rust", "challenge-rust-1");
+    insert_stage_result_with_language(&db, repository_id, "javascript", "challenge-js-1");
+    insert_stage_result_with_language(&db, repository_id, "rust", "challenge-rust-2");
+
+    let repos = dao.get_all_repositories_with_languages().unwrap();
+    let repo = repos
+        .iter()
+        .find(|r| r.user_name == "languser" && r.repository_name == "langrepo")
+        .expect("Repository should exist");
+
+    assert_eq!(
+        repo.languages.len(),
+        2,
+        "DISTINCT should de-duplicate the doubled rust language entry"
+    );
+    assert!(repo.languages.iter().any(|l| l == "rust"));
+    assert!(repo.languages.iter().any(|l| l == "javascript"));
+}
+
+#[test]
+fn test_get_all_repositories_with_languages_handles_empty_database() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let dao = RepositoryDao::new(Arc::clone(&db));
+
+    let repos = dao.get_all_repositories_with_languages().unwrap();
+    assert!(repos.is_empty());
+}
+
+#[test]
+fn test_find_repository_distinguishes_by_user_and_name() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let dao = RepositoryDao::new(Arc::clone(&db));
+
+    let repo_a = GitRepository {
+        user_name: "alice".to_string(),
+        repository_name: "project".to_string(),
+        remote_url: "https://github.com/alice/project".to_string(),
+        branch: None,
+        commit_hash: None,
+        is_dirty: false,
+        root_path: None,
+    };
+    let repo_b = GitRepository {
+        user_name: "bob".to_string(),
+        repository_name: "project".to_string(),
+        remote_url: "https://github.com/bob/project".to_string(),
+        branch: None,
+        commit_hash: None,
+        is_dirty: false,
+        root_path: None,
+    };
+
+    let id_a = dao.ensure_repository(&repo_a).unwrap();
+    let id_b = dao.ensure_repository(&repo_b).unwrap();
+    assert_ne!(id_a, id_b);
+
+    let found_a = dao.find_repository("alice", "project").unwrap().unwrap();
+    let found_b = dao.find_repository("bob", "project").unwrap().unwrap();
+    assert_eq!(found_a.id, id_a);
+    assert_eq!(found_b.id, id_b);
+    assert_eq!(found_a.remote_url, "https://github.com/alice/project");
+}
+
+#[test]
+fn test_get_repository_by_id_returns_correct_record() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let dao = RepositoryDao::new(Arc::clone(&db));
+
+    let repos = [
+        ("first", "repo_one"),
+        ("second", "repo_two"),
+        ("third", "repo_three"),
+    ];
+    let mut ids = Vec::new();
+    for (user, name) in repos.iter() {
+        let git_repo = GitRepository {
+            user_name: user.to_string(),
+            repository_name: name.to_string(),
+            remote_url: format!("https://github.com/{}/{}", user, name),
+            branch: None,
+            commit_hash: None,
+            is_dirty: false,
+            root_path: None,
+        };
+        ids.push(dao.ensure_repository(&git_repo).unwrap());
+    }
+
+    for ((user, name), id) in repos.iter().zip(ids.iter()) {
+        let found = dao.get_repository_by_id(*id).unwrap().unwrap();
+        assert_eq!(found.user_name, *user);
+        assert_eq!(found.repository_name, *name);
+    }
 }
 
 #[test]

--- a/tests/unit/infrastructure/database/daos/session_dao_tests.rs
+++ b/tests/unit/infrastructure/database/daos/session_dao_tests.rs
@@ -1219,6 +1219,45 @@ fn test_get_sessions_filtered_unknown_sort_falls_back_to_date() {
 }
 
 #[test]
+fn test_save_session_result_records_tier_name_for_each_tier() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+
+    let git_repo = make_git_repo("tieruser", "tierrepo", "tiercommit");
+    let repository_id = repo_dao.ensure_repository(&git_repo).unwrap();
+
+    let cases = [
+        (100.0, "Beginner"),
+        (6000.0, "Intermediate"),
+        (8000.0, "Advanced"),
+        (10000.0, "Expert"),
+        (12000.0, "Legendary"),
+    ];
+
+    for (score, expected_tier) in cases {
+        let session_id =
+            seed_session_with_score(&db, &session_dao, repository_id, &git_repo, score, 1000);
+
+        let conn = db.get_connection().unwrap();
+        let tier: String = conn
+            .query_row(
+                "SELECT tier_name FROM session_results WHERE session_id = ?",
+                rusqlite::params![session_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            tier, expected_tier,
+            "score {} should yield tier {}",
+            score, expected_tier
+        );
+    }
+}
+
+#[test]
 fn test_get_sessions_filtered_combines_repository_and_date_filters() {
     let db_impl = Database::new().unwrap();
     db_impl.init().unwrap();

--- a/tests/unit/infrastructure/database/daos/session_dao_tests.rs
+++ b/tests/unit/infrastructure/database/daos/session_dao_tests.rs
@@ -943,3 +943,310 @@ fn test_get_session_stage_results() {
     assert_eq!(stage_results[0].language, Some("rust".to_string()));
     assert_eq!(stage_results[1].language, Some("rust".to_string()));
 }
+
+fn make_git_repo(user: &str, repo: &str, commit: &str) -> GitRepository {
+    GitRepository {
+        user_name: user.to_string(),
+        repository_name: repo.to_string(),
+        remote_url: format!("https://github.com/{}/{}", user, repo),
+        branch: Some("main".to_string()),
+        commit_hash: Some(commit.to_string()),
+        is_dirty: false,
+        root_path: None,
+    }
+}
+
+fn seed_session_with_score(
+    db: &Arc<dyn DatabaseInterface>,
+    session_dao: &SessionDao,
+    repository_id: i64,
+    git_repo: &GitRepository,
+    score: f64,
+    duration_ms: u64,
+) -> i64 {
+    let mut session_result = SessionResult::new();
+    session_result.session_score = score;
+    session_result.session_duration = Duration::from_millis(duration_ms);
+
+    let conn = db.get_connection().unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    let session_id = session_dao
+        .create_session_in_transaction(
+            &tx,
+            Some(repository_id),
+            &session_result,
+            Some(git_repo),
+            "normal",
+            Some("easy"),
+        )
+        .unwrap();
+
+    session_dao
+        .save_session_result_in_transaction(
+            &tx,
+            gittype::domain::models::storage::SaveSessionResultParams {
+                session_id,
+                repository_id: Some(repository_id),
+                session_result: &session_result,
+                stage_engines: &[],
+                game_mode: "normal",
+                difficulty_level: Some("easy"),
+            },
+        )
+        .unwrap();
+    tx.commit().unwrap();
+    drop(conn);
+
+    session_id
+}
+
+#[test]
+fn test_save_session_result_in_transaction_requires_repository_id() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+
+    let git_repo = make_git_repo("noreuser", "norerepo", "norecommit");
+    let repository_id = repo_dao.ensure_repository(&git_repo).unwrap();
+
+    let mut session_result = SessionResult::new();
+    session_result.session_score = 50.0;
+
+    let conn = db.get_connection().unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    let session_id = session_dao
+        .create_session_in_transaction(
+            &tx,
+            Some(repository_id),
+            &session_result,
+            Some(&git_repo),
+            "normal",
+            Some("easy"),
+        )
+        .unwrap();
+
+    let err = session_dao
+        .save_session_result_in_transaction(
+            &tx,
+            gittype::domain::models::storage::SaveSessionResultParams {
+                session_id,
+                repository_id: None,
+                session_result: &session_result,
+                stage_engines: &[],
+                game_mode: "normal",
+                difficulty_level: Some("easy"),
+            },
+        )
+        .expect_err("missing repository_id must fail");
+
+    assert!(
+        matches!(err, gittype::GitTypeError::TerminalError(ref m) if m.contains("repository_id is required")),
+        "Expected TerminalError about missing repository_id, got: {:?}",
+        err,
+    );
+}
+
+#[test]
+fn test_save_stage_result_in_transaction_requires_repository_id() {
+    use gittype::domain::models::storage::SaveStageParams;
+    use gittype::domain::models::StageResult;
+
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+    let challenge_dao = ChallengeDao::new(Arc::clone(&db));
+
+    let git_repo = make_git_repo("stagenoresuser", "stagenoresrepo", "stagenorecom");
+    let repository_id = repo_dao.ensure_repository(&git_repo).unwrap();
+
+    let challenge = Challenge::new("stage-nore-1".to_string(), "fn x() {}".to_string())
+        .with_language("rust".to_string())
+        .with_difficulty_level(DifficultyLevel::Easy);
+
+    let conn = db.get_connection().unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    challenge_dao
+        .ensure_challenge_in_transaction(&tx, &challenge)
+        .unwrap();
+    tx.commit().unwrap();
+    drop(conn);
+
+    let session_id =
+        seed_session_with_score(&db, &session_dao, repository_id, &git_repo, 100.0, 1000);
+
+    let stage_result = StageResult::default();
+
+    let conn = db.get_connection().unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+
+    let err = session_dao
+        .save_stage_result_in_transaction(
+            &tx,
+            SaveStageParams {
+                session_id,
+                repository_id: None,
+                stage_index: 0,
+                stage_name: "stage-nore-1",
+                stage_result: &stage_result,
+                keystrokes: 0,
+                challenge: Some(&challenge),
+            },
+        )
+        .expect_err("missing repository_id must fail for stage_results");
+
+    assert!(
+        matches!(err, gittype::GitTypeError::TerminalError(ref m) if m.contains("repository_id is required")),
+        "Expected TerminalError about missing repository_id, got: {:?}",
+        err,
+    );
+}
+
+#[test]
+fn test_get_sessions_filtered_sorted_by_repository() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+
+    let repo_a = make_git_repo("rep_a_user", "rep_a_repo", "rep-a-1");
+    let repo_b = make_git_repo("rep_b_user", "rep_b_repo", "rep-b-1");
+    let id_a = repo_dao.ensure_repository(&repo_a).unwrap();
+    let id_b = repo_dao.ensure_repository(&repo_b).unwrap();
+
+    seed_session_with_score(&db, &session_dao, id_b, &repo_b, 50.0, 1000);
+    seed_session_with_score(&db, &session_dao, id_a, &repo_a, 60.0, 1000);
+
+    let sessions = session_dao
+        .get_sessions_filtered(None, None, "repository", false)
+        .unwrap();
+
+    let repo_ids: Vec<_> = sessions
+        .iter()
+        .map(|s| s.repository_id.expect("repository_id present"))
+        .collect();
+    assert!(repo_ids.len() >= 2, "Should return at least 2 sessions");
+
+    for window in repo_ids.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "When sort_descending=false, repository_id should be non-decreasing"
+        );
+    }
+}
+
+#[test]
+fn test_get_sessions_filtered_sorted_by_duration_ascending() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+
+    let git_repo = make_git_repo("duruser", "durrepo", "durcommit");
+    let repository_id = repo_dao.ensure_repository(&git_repo).unwrap();
+
+    let session_ids = [
+        seed_session_with_score(&db, &session_dao, repository_id, &git_repo, 100.0, 5000),
+        seed_session_with_score(&db, &session_dao, repository_id, &git_repo, 200.0, 1000),
+        seed_session_with_score(&db, &session_dao, repository_id, &git_repo, 150.0, 3000),
+    ];
+
+    let sessions = session_dao
+        .get_sessions_filtered(Some(repository_id), None, "duration", false)
+        .unwrap();
+
+    assert_eq!(
+        sessions.len(),
+        session_ids.len(),
+        "Should return all seeded sessions"
+    );
+
+    let durations: Vec<_> = sessions
+        .iter()
+        .map(|s| {
+            session_dao
+                .get_session_result(s.id)
+                .unwrap()
+                .unwrap()
+                .duration_ms
+        })
+        .collect();
+
+    for window in durations.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "duration ascending should be non-decreasing, got {:?}",
+            durations,
+        );
+    }
+}
+
+#[test]
+fn test_get_sessions_filtered_unknown_sort_falls_back_to_date() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+
+    let git_repo = make_git_repo("unkuser", "unkrepo", "unkcommit");
+    let repository_id = repo_dao.ensure_repository(&git_repo).unwrap();
+
+    seed_session_with_score(&db, &session_dao, repository_id, &git_repo, 100.0, 1000);
+    seed_session_with_score(&db, &session_dao, repository_id, &git_repo, 200.0, 1000);
+
+    let sessions = session_dao
+        .get_sessions_filtered(Some(repository_id), None, "not-a-real-column", true)
+        .unwrap();
+
+    assert!(
+        !sessions.is_empty(),
+        "Unknown sort_by must fall back to date sort and still return rows"
+    );
+
+    let started_dates: Vec<_> = sessions.iter().map(|s| s.started_at).collect();
+    for window in started_dates.windows(2) {
+        assert!(
+            window[0] >= window[1],
+            "Default-fallback descending sort by date should be non-increasing"
+        );
+    }
+}
+
+#[test]
+fn test_get_sessions_filtered_combines_repository_and_date_filters() {
+    let db_impl = Database::new().unwrap();
+    db_impl.init().unwrap();
+    let db = Arc::new(db_impl) as Arc<dyn DatabaseInterface>;
+    let session_dao = SessionDao::new(Arc::clone(&db));
+    let repo_dao = RepositoryDao::new(Arc::clone(&db));
+
+    let target = make_git_repo("comb_user", "comb_repo", "comb1");
+    let other = make_git_repo("other_user", "other_repo", "comb2");
+    let target_id = repo_dao.ensure_repository(&target).unwrap();
+    let other_id = repo_dao.ensure_repository(&other).unwrap();
+
+    seed_session_with_score(&db, &session_dao, target_id, &target, 100.0, 1000);
+    seed_session_with_score(&db, &session_dao, other_id, &other, 100.0, 1000);
+
+    let sessions = session_dao
+        .get_sessions_filtered(Some(target_id), Some(30), "date", true)
+        .unwrap();
+
+    assert!(
+        !sessions.is_empty(),
+        "Should return target sessions within the date window"
+    );
+    for session in &sessions {
+        assert_eq!(
+            session.repository_id,
+            Some(target_id),
+            "Combined filters must only yield the target repository's sessions"
+        );
+    }
+}

--- a/tests/unit/infrastructure/database/database_tests.rs
+++ b/tests/unit/infrastructure/database/database_tests.rs
@@ -1,4 +1,4 @@
-use gittype::infrastructure::database::database::Database;
+use gittype::infrastructure::database::database::{Database, DatabaseInterface};
 use gittype::infrastructure::database::migrations::get_latest_version;
 
 #[test]
@@ -182,6 +182,24 @@ fn test_foreign_key_constraints() {
         [],
     );
     assert!(result.is_err(), "Should fail due to foreign key constraint");
+}
+
+#[test]
+fn test_trait_dispatch_get_connection_init_tables_and_version() {
+    let db = Database::new().unwrap();
+    let trait_obj: &dyn DatabaseInterface = &db;
+
+    // Cover trait dispatch for get_connection (lines 173-175)
+    let conn = trait_obj.get_connection().unwrap();
+    assert!(conn.prepare("SELECT 1").is_ok());
+    drop(conn);
+
+    // Cover trait dispatch for init_tables (lines 177-179): idempotent re-run.
+    trait_obj.init_tables().unwrap();
+
+    // Cover trait dispatch for get_current_schema_version (lines 181-183).
+    let version = trait_obj.get_current_schema_version().unwrap();
+    assert_eq!(version, get_latest_version());
 }
 
 #[test]

--- a/tests/unit/infrastructure/database/migrations_tests.rs
+++ b/tests/unit/infrastructure/database/migrations_tests.rs
@@ -1,0 +1,89 @@
+use gittype::infrastructure::database::migrations::v001_initial_schema::InitialSchema;
+use gittype::infrastructure::database::migrations::{
+    get_all_migrations, get_latest_version, Migration,
+};
+use rusqlite::Connection;
+
+fn table_exists(conn: &Connection, table_name: &str) -> bool {
+    let count: i32 = conn
+        .prepare("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?")
+        .unwrap()
+        .query_row([table_name], |row| row.get(0))
+        .unwrap();
+    count == 1
+}
+
+fn index_exists(conn: &Connection, index_name: &str) -> bool {
+    let count: i32 = conn
+        .prepare("SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?")
+        .unwrap()
+        .query_row([index_name], |row| row.get(0))
+        .unwrap();
+    count == 1
+}
+
+#[test]
+fn initial_schema_reports_version_one() {
+    let migration = InitialSchema;
+    assert_eq!(migration.version(), 1);
+}
+
+#[test]
+fn initial_schema_description_mentions_normalized_schema() {
+    let migration = InitialSchema;
+    let description = migration.description();
+    assert!(description.contains("normalized database schema"));
+    assert!(description.contains("repositories"));
+    assert!(description.contains("sessions"));
+}
+
+#[test]
+fn initial_schema_up_creates_all_expected_tables() {
+    let conn = Connection::open_in_memory().unwrap();
+    InitialSchema.up(&conn).unwrap();
+
+    assert!(table_exists(&conn, "repositories"));
+    assert!(table_exists(&conn, "sessions"));
+    assert!(table_exists(&conn, "challenges"));
+    assert!(table_exists(&conn, "stages"));
+    assert!(table_exists(&conn, "session_results"));
+    assert!(table_exists(&conn, "stage_results"));
+}
+
+#[test]
+fn initial_schema_up_creates_all_expected_indexes() {
+    let conn = Connection::open_in_memory().unwrap();
+    InitialSchema.up(&conn).unwrap();
+
+    assert!(index_exists(&conn, "idx_stage_results_repo_date"));
+    assert!(index_exists(&conn, "idx_stage_results_language"));
+    assert!(index_exists(&conn, "idx_stage_results_session"));
+    assert!(index_exists(&conn, "idx_session_results_repo_date"));
+    assert!(index_exists(&conn, "idx_sessions_repo_date"));
+}
+
+#[test]
+fn initial_schema_up_is_idempotent() {
+    let conn = Connection::open_in_memory().unwrap();
+    InitialSchema.up(&conn).unwrap();
+    InitialSchema.up(&conn).unwrap();
+
+    assert!(table_exists(&conn, "repositories"));
+    assert!(table_exists(&conn, "stage_results"));
+}
+
+#[test]
+fn migration_trait_dispatch_invokes_version_and_description() {
+    let migration: Box<dyn Migration> = Box::new(InitialSchema);
+    assert_eq!(migration.version(), 1);
+    assert!(!migration.description().is_empty());
+}
+
+#[test]
+fn get_all_migrations_returns_ordered_versions_up_to_latest() {
+    let migrations = get_all_migrations();
+    assert!(!migrations.is_empty());
+
+    let latest = get_latest_version();
+    assert!(migrations.iter().any(|m| m.version() == latest));
+}

--- a/tests/unit/infrastructure/database/mod.rs
+++ b/tests/unit/infrastructure/database/mod.rs
@@ -1,2 +1,3 @@
 pub mod daos;
 pub mod database_tests;
+pub mod migrations_tests;

--- a/tests/unit/infrastructure/git/local_git_repository_client_test.rs
+++ b/tests/unit/infrastructure/git/local_git_repository_client_test.rs
@@ -1,8 +1,10 @@
 #[cfg(test)]
 mod tests {
     use git2::{Repository, Signature};
+    use gittype::infrastructure::git::local::local_git_repository_client::LocalGitRepositoryClientInterface;
     use gittype::infrastructure::git::LocalGitRepositoryClient;
     use gittype::GitTypeError;
+    use std::sync::Arc;
 
     fn commit_file(repo: &Repository, name: &str, content: &str) -> String {
         let workdir = repo.workdir().unwrap();
@@ -148,5 +150,134 @@ mod tests {
             git_repository.root_path,
             Some(temp_dir.path().to_path_buf())
         );
+    }
+
+    #[test]
+    fn test_extract_git_repository_returns_error_when_origin_missing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hello");
+
+        let client = LocalGitRepositoryClient::new();
+        let result = client.extract_git_repository(temp_dir.path());
+
+        let message = match result {
+            Err(GitTypeError::ExtractionFailed(msg)) => msg,
+            other => panic!("expected ExtractionFailed, got {:?}", other),
+        };
+        assert!(
+            message.starts_with("Failed to find origin remote"),
+            "unexpected message: {message}"
+        );
+    }
+
+    #[test]
+    fn test_extract_git_repository_returns_error_for_unparseable_remote_url() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        repo.remote("origin", "not-a-valid-remote-url").unwrap();
+        commit_file(&repo, "README.md", "hello");
+
+        let client = LocalGitRepositoryClient::new();
+        let result = client.extract_git_repository(temp_dir.path());
+
+        assert!(matches!(
+            result,
+            Err(GitTypeError::ExtractionFailed(msg))
+            if msg == "Failed to parse remote URL"
+        ));
+    }
+
+    #[test]
+    fn test_extract_git_repository_reports_dirty_working_tree() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        repo.remote("origin", "https://github.com/octocat/hello-world.git")
+            .unwrap();
+        commit_file(&repo, "README.md", "hello");
+        std::fs::write(temp_dir.path().join("dirty.txt"), "uncommitted").unwrap();
+
+        let client = LocalGitRepositoryClient::new();
+        let git_repository = client.extract_git_repository(temp_dir.path()).unwrap();
+
+        assert!(
+            git_repository.is_dirty,
+            "expected uncommitted file to mark repository as dirty"
+        );
+    }
+
+    #[test]
+    fn test_create_from_local_path_uses_origin_url_when_available() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        repo.remote("origin", "https://github.com/octocat/hello-world.git")
+            .unwrap();
+        let commit_hash = commit_file(&repo, "README.md", "hello");
+
+        let client = LocalGitRepositoryClient::new();
+        let git_repository = client.create_from_local_path(temp_dir.path()).unwrap();
+
+        assert_eq!(git_repository.user_name, "octocat");
+        assert_eq!(git_repository.repository_name, "hello-world");
+        assert_eq!(
+            git_repository.remote_url,
+            "https://github.com/octocat/hello-world.git"
+        );
+        assert_eq!(git_repository.commit_hash, Some(commit_hash));
+        assert!(git_repository.branch.is_some());
+        assert!(!git_repository.is_dirty);
+    }
+
+    #[test]
+    fn test_create_from_local_path_falls_back_to_unknown_for_unparseable_origin() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        repo.remote("origin", "totally-bogus-origin").unwrap();
+
+        let client = LocalGitRepositoryClient::new();
+        let git_repository = client.create_from_local_path(temp_dir.path()).unwrap();
+
+        assert_eq!(git_repository.user_name, "unknown");
+        assert_eq!(git_repository.repository_name, "unknown");
+        assert_eq!(git_repository.remote_url, "totally-bogus-origin");
+    }
+
+    #[test]
+    fn test_create_from_local_path_returns_error_for_non_git_directory() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let client = LocalGitRepositoryClient::new();
+        let result = client.create_from_local_path(temp_dir.path());
+
+        assert!(matches!(
+            result,
+            Err(GitTypeError::ExtractionFailed(msg))
+            if msg.starts_with("Failed to open git repository")
+        ));
+    }
+
+    #[test]
+    fn test_interface_dispatch_delegates_to_inherent_methods() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        repo.remote("origin", "https://github.com/octocat/hello-world.git")
+            .unwrap();
+        commit_file(&repo, "README.md", "hello");
+
+        let client: Arc<dyn LocalGitRepositoryClientInterface> =
+            Arc::new(LocalGitRepositoryClient::new());
+
+        assert!(client.is_git_repository(temp_dir.path()));
+
+        let nested = temp_dir.path().join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(
+            client.get_repository_root(&nested),
+            Some(temp_dir.path().to_path_buf())
+        );
+
+        let git_repository = client.extract_git_repository(temp_dir.path()).unwrap();
+        assert_eq!(git_repository.user_name, "octocat");
+        assert_eq!(git_repository.repository_name, "hello-world");
     }
 }

--- a/tests/unit/infrastructure/logging_tests.rs
+++ b/tests/unit/infrastructure/logging_tests.rs
@@ -1,5 +1,6 @@
 use gittype::infrastructure::logging::{
-    get_environment_context, get_log_directory, log_error_to_file, setup_console_logging,
+    get_current_log_file_path, get_environment_context, get_log_directory, log_error_to_file,
+    log_panic_to_file, setup_console_logging,
 };
 use gittype::GitTypeError;
 use std::path::{Path, PathBuf};
@@ -7,6 +8,7 @@ use std::sync::Mutex;
 use tempfile::TempDir;
 
 static CURRENT_DIR_LOCK: Mutex<()> = Mutex::new(());
+static PANIC_HOOK_LOCK: Mutex<()> = Mutex::new(());
 
 struct CurrentDirGuard {
     original: PathBuf,
@@ -143,4 +145,60 @@ fn log_error_to_file_writes_error_log_in_logs_directory() {
 
     assert!(log_content.contains("ERROR MESSAGE: Validation error: coverage validation failure"));
     assert!(log_content.contains("WORKING_DIR:"));
+}
+
+#[test]
+fn get_current_log_file_path_returns_optional_string() {
+    // `setup_logging` may or may not have been called by earlier tests in this
+    // process; either way `get_current_log_file_path` must return without
+    // panicking and yield an `Option<String>`.
+    if let Some(p) = get_current_log_file_path() {
+        assert!(!p.is_empty());
+    }
+}
+
+type BoxedPanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync + 'static>;
+
+struct PanicHookGuard {
+    original: Option<BoxedPanicHook>,
+}
+
+impl Drop for PanicHookGuard {
+    fn drop(&mut self) {
+        if let Some(hook) = self.original.take() {
+            std::panic::set_hook(hook);
+        }
+    }
+}
+
+fn run_with_panic_hook<F>(body: F)
+where
+    F: FnOnce() + std::panic::UnwindSafe,
+{
+    let _lock = PANIC_HOOK_LOCK.lock().unwrap();
+    let original = std::panic::take_hook();
+    let guard = PanicHookGuard {
+        original: Some(original),
+    };
+    std::panic::set_hook(Box::new(|info| {
+        log_panic_to_file(info);
+    }));
+    let _ = std::panic::catch_unwind(body);
+    drop(guard);
+}
+
+#[test]
+fn log_panic_to_file_handles_str_payload() {
+    run_with_panic_hook(|| panic!("static-str panic payload"));
+}
+
+#[test]
+fn log_panic_to_file_handles_string_payload() {
+    let dynamic = String::from("dynamic");
+    run_with_panic_hook(move || panic!("formatted {} panic", dynamic));
+}
+
+#[test]
+fn log_panic_to_file_handles_non_string_payload() {
+    run_with_panic_hook(|| std::panic::panic_any(42_u32));
 }

--- a/tests/unit/infrastructure/logging_tests.rs
+++ b/tests/unit/infrastructure/logging_tests.rs
@@ -148,6 +148,60 @@ fn log_error_to_file_writes_error_log_in_logs_directory() {
 }
 
 #[test]
+fn log_error_to_file_falls_back_to_cwd_when_logs_dir_is_missing() {
+    let _lock = CURRENT_DIR_LOCK.lock().unwrap();
+    let temp_dir = TempDir::new().unwrap();
+    let _guard = CurrentDirGuard::enter(temp_dir.path());
+
+    log_error_to_file(&GitTypeError::ValidationError(
+        "fallback path test".to_string(),
+    ));
+
+    let fallback_log = std::fs::read_dir(temp_dir.path())
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("gittype_error_") && name.ends_with(".log"))
+        });
+
+    assert!(
+        fallback_log.is_some(),
+        "expected gittype_error_*.log in cwd when logs/ directory is absent"
+    );
+
+    let log_content = std::fs::read_to_string(fallback_log.unwrap()).unwrap();
+    assert!(log_content.contains("ERROR MESSAGE: Validation error: fallback path test"));
+}
+
+#[test]
+fn log_error_to_file_writes_chained_source_errors() {
+    let _lock = CURRENT_DIR_LOCK.lock().unwrap();
+    let temp_dir = TempDir::new().unwrap();
+    let logs_dir = temp_dir.path().join("logs");
+    std::fs::create_dir_all(&logs_dir).unwrap();
+    let _guard = CurrentDirGuard::enter(temp_dir.path());
+
+    let io_err = std::io::Error::other("underlying io failure");
+    log_error_to_file(&GitTypeError::IoError(io_err));
+
+    let log_path = std::fs::read_dir(&logs_dir)
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("error_") && name.ends_with(".log"))
+        })
+        .expect("error log file should exist in logs/");
+    let log_content = std::fs::read_to_string(log_path).unwrap();
+
+    assert!(log_content.contains("CAUSED BY (level 1)"));
+    assert!(log_content.contains("underlying io failure"));
+}
+
+#[test]
 fn get_current_log_file_path_returns_optional_string() {
     // `setup_logging` may or may not have been called by earlier tests in this
     // process; either way `get_current_log_file_path` must return without

--- a/tests/unit/infrastructure/oss_insight_client_tests.rs
+++ b/tests/unit/infrastructure/oss_insight_client_tests.rs
@@ -25,3 +25,15 @@ async fn trait_fetch_trending_repositories_uses_mock_data() {
 
     assert!(repositories.is_empty());
 }
+
+#[tokio::test]
+async fn default_constructs_a_usable_client() {
+    let client: OssInsightClient = Default::default();
+
+    let repositories = client
+        .fetch_trending_repositories(None, "monthly")
+        .await
+        .unwrap();
+
+    assert!(repositories.is_empty());
+}

--- a/tests/unit/infrastructure/storage/compressed_file_storage_tests.rs
+++ b/tests/unit/infrastructure/storage/compressed_file_storage_tests.rs
@@ -161,6 +161,17 @@ mod mock_tests {
     }
 
     #[test]
+    fn compressed_file_storage_load_with_incompatible_type_returns_error() {
+        let storage = CompressedFileStorage::new();
+        let path = Path::new("/test/mismatched.bin");
+
+        storage.save::<()>(path, &()).unwrap();
+
+        let result: Result<Option<TestData>, _> = storage.load(path);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn compressed_file_storage_clone() {
         let storage = CompressedFileStorage::new();
         let data = TestData {

--- a/tests/unit/infrastructure/storage/file_storage_tests.rs
+++ b/tests/unit/infrastructure/storage/file_storage_tests.rs
@@ -154,4 +154,30 @@ mod mock_tests {
 
         assert!(result.is_err());
     }
+
+    #[test]
+    fn file_storage_read_dir_returns_not_implemented_error() {
+        use std::path::Path;
+
+        let storage = FileStorage::new();
+        let result = storage.read_dir(Path::new("/test"));
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            gittype::GitTypeError::ExtractionFailed(message)
+                if message.contains("Mock read_dir not implemented")
+        ));
+    }
+
+    #[test]
+    fn file_storage_remove_dir_all_succeeds() {
+        use std::path::Path;
+
+        let storage = FileStorage::new();
+        let result = storage.remove_dir_all(Path::new("/test"));
+
+        assert!(result.is_ok());
+    }
 }

--- a/tests/unit/presentation/cli_repo_command_tests.rs
+++ b/tests/unit/presentation/cli_repo_command_tests.rs
@@ -1,4 +1,4 @@
-use gittype::presentation::cli::commands::{run_repo_list, run_repo_play};
+use gittype::presentation::cli::commands::{run_repo_clear, run_repo_list, run_repo_play};
 use gittype::{GitTypeError, Result};
 
 fn assert_non_tty_terminal_error(result: Result<()>) {
@@ -21,4 +21,28 @@ fn run_repo_list_returns_terminal_error_without_tty() {
 #[test]
 fn run_repo_play_returns_terminal_error_without_tty() {
     assert_non_tty_terminal_error(run_repo_play());
+}
+
+#[test]
+fn run_repo_clear_with_force_returns_ok_when_no_cached_repos_dir() {
+    let result = run_repo_clear(true);
+
+    assert!(
+        result.is_ok(),
+        "run_repo_clear should succeed and short-circuit when the test-mocks FileStorage \
+         reports no repos directory, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn run_repo_clear_without_force_returns_ok_when_no_cached_repos_dir() {
+    let result = run_repo_clear(false);
+
+    assert!(
+        result.is_ok(),
+        "run_repo_clear should succeed and short-circuit when the test-mocks FileStorage \
+         reports no repos directory, got {:?}",
+        result
+    );
 }

--- a/tests/unit/presentation/cli_screen_runner_tests.rs
+++ b/tests/unit/presentation/cli_screen_runner_tests.rs
@@ -50,3 +50,20 @@ fn cleanup_succeeds_when_terminal_is_active() {
 
     assert!(context.cleanup().is_ok());
 }
+
+#[test]
+fn context_run_screen_returns_terminal_error_without_tty() {
+    if atty::is(atty::Stream::Stdout) {
+        return;
+    }
+
+    let context = ScreenRunnerContext::new_for_test(false);
+
+    let result = context.run_screen::<RepoListScreen, (), (), fn(&RepoListScreen) -> Option<()>>(
+        ScreenType::RepoList,
+        None::<()>,
+        None,
+    );
+
+    assert_non_tty_terminal_error(result);
+}

--- a/tests/unit/presentation/sharing_tests.rs
+++ b/tests/unit/presentation/sharing_tests.rs
@@ -169,3 +169,98 @@ fn sharing_platform_clone() {
     let p2 = p.clone();
     assert_eq!(p.name(), p2.name());
 }
+
+#[test]
+fn sharing_platform_debug_format_is_not_empty() {
+    let labels: Vec<String> = SharingPlatform::all()
+        .into_iter()
+        .map(|p| format!("{:?}", p))
+        .collect();
+
+    assert_eq!(labels.len(), 4);
+    assert!(labels.iter().all(|s| !s.is_empty()));
+}
+
+// ---------------------------------------------------------------------------
+// share_result — under test-mocks, browser::open_url always returns Ok, so
+// these tests exercise the success path (and the open_browser wrapper) without
+// touching the real browser or the fallback URL display.
+// ---------------------------------------------------------------------------
+#[test]
+fn share_result_opens_browser_for_every_platform_without_repo() {
+    let metrics = make_metrics(125.0, 270.0, 1, 4);
+
+    for platform in SharingPlatform::all() {
+        let result = SharingService::share_result(&metrics, platform, &None);
+        assert!(result.is_ok(), "share_result should succeed under mocks");
+    }
+}
+
+#[test]
+fn share_result_opens_browser_for_every_platform_with_repo() {
+    let metrics = make_metrics(99.0, 175.0, 0, 1);
+    let repo = make_repo();
+
+    for platform in SharingPlatform::all() {
+        let result = SharingService::share_result(&metrics, platform, &Some(repo.clone()));
+        assert!(
+            result.is_ok(),
+            "share_result with repo should succeed under mocks"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// generate_share_url URL-encoding sanity checks
+// ---------------------------------------------------------------------------
+#[test]
+fn generate_share_url_x_encodes_text_payload() {
+    let metrics = make_metrics(100.0, 250.0, 2, 1);
+    let url = SharingService::generate_share_url(&metrics, &SharingPlatform::X, &None);
+
+    assert!(url.contains("text="));
+    assert!(
+        !url.contains(' '),
+        "URL should be percent-encoded, found raw spaces in {url}"
+    );
+    assert!(!url.contains('\n'), "URL should not contain raw newlines");
+}
+
+#[test]
+fn generate_share_url_reddit_includes_rank_name_in_title() {
+    let metrics = make_metrics(0.0, 0.0, 0, 0);
+    let url = SharingService::generate_share_url(&metrics, &SharingPlatform::Reddit, &None);
+
+    let title_segment = url
+        .split("title=")
+        .nth(1)
+        .and_then(|rest| rest.split('&').next())
+        .expect("reddit URL must have a title= segment");
+
+    let title = urlencoding::decode(title_segment).expect("title must be valid percent-encoding");
+    assert!(title.contains("rank"));
+    assert!(title.contains("0 points"));
+}
+
+#[test]
+fn generate_share_url_facebook_encodes_repo_link_separately_from_quote() {
+    let metrics = make_metrics(10.0, 20.0, 0, 0);
+    let url = SharingService::generate_share_url(&metrics, &SharingPlatform::Facebook, &None);
+
+    let u_segment = url
+        .split("u=")
+        .nth(1)
+        .and_then(|rest| rest.split('&').next())
+        .expect("facebook URL must have a u= segment");
+    let quote_segment = url
+        .split("quote=")
+        .nth(1)
+        .expect("facebook URL must have a quote= segment");
+
+    let decoded_u = urlencoding::decode(u_segment).expect("u must be valid percent-encoding");
+    let decoded_quote =
+        urlencoding::decode(quote_segment).expect("quote must be valid percent-encoding");
+
+    assert_eq!(decoded_u, "https://github.com/unhappychoice/gittype");
+    assert!(decoded_quote.contains("gittype"));
+}

--- a/tests/unit/presentation/tui/best_records_view_tests.rs
+++ b/tests/unit/presentation/tui/best_records_view_tests.rs
@@ -1,0 +1,153 @@
+use gittype::domain::models::color_mode::ColorMode;
+use gittype::domain::models::color_scheme::{ColorScheme, ThemeFile};
+use gittype::domain::models::storage::SessionResultData;
+use gittype::domain::models::SessionResult;
+use gittype::domain::repositories::session_repository::{BestRecords, BestStatus};
+use gittype::presentation::tui::views::session_detail_dialog::BestRecordsView;
+use gittype::presentation::ui::colors::Colors;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::Terminal;
+
+fn default_colors() -> Colors {
+    let json = include_str!("../../../../assets/themes/default.json");
+    let theme: ThemeFile = serde_json::from_str(json).unwrap();
+    Colors::new(ColorScheme::from_theme_file(&theme, &ColorMode::Dark))
+}
+
+fn buffer_text(buffer: &Buffer) -> String {
+    (0..buffer.area.height)
+        .map(|row| {
+            (0..buffer.area.width)
+                .map(|column| buffer[(column, row)].symbol().to_string())
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn sample_result(score: f64, cpm: f64, accuracy: f64) -> SessionResultData {
+    SessionResultData {
+        keystrokes: 100,
+        mistakes: 0,
+        duration_ms: 30_000,
+        wpm: cpm / 5.0,
+        cpm,
+        accuracy,
+        stages_completed: 1,
+        stages_attempted: 1,
+        stages_skipped: 0,
+        score,
+        rank_name: None,
+        tier_name: None,
+        rank_position: None,
+        rank_total: None,
+        position: None,
+        total: None,
+    }
+}
+
+fn render_to_string(
+    session_result: &SessionResult,
+    best_status: Option<&BestStatus>,
+    best_records: Option<&BestRecords>,
+) -> String {
+    let colors = default_colors();
+    let backend = TestBackend::new(120, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|frame| {
+            BestRecordsView::render(
+                frame,
+                Rect::new(0, 0, 120, 12),
+                session_result,
+                best_status,
+                best_records,
+                &colors,
+            );
+        })
+        .unwrap();
+
+    buffer_text(terminal.backend().buffer())
+}
+
+#[test]
+fn render_without_best_records_draws_nothing() {
+    let session = SessionResult::new();
+
+    let output = render_to_string(&session, None, None);
+
+    assert!(!output.contains("BEST RECORDS"));
+    assert!(!output.contains("NEW PB"));
+}
+
+#[test]
+fn render_uses_best_status_flags_for_new_pb_markers() {
+    let mut session = SessionResult::new();
+    session.session_score = 200.0;
+
+    let best_status = BestStatus {
+        is_todays_best: true,
+        is_weekly_best: false,
+        is_all_time_best: true,
+        best_type: None,
+        todays_best_score: 0.0,
+        weekly_best_score: 0.0,
+        all_time_best_score: 0.0,
+    };
+
+    let best_records = BestRecords {
+        todays_best: Some(sample_result(150.0, 300.0, 95.0)),
+        weekly_best: Some(sample_result(220.0, 320.0, 96.0)),
+        all_time_best: Some(sample_result(180.0, 340.0, 97.0)),
+    };
+
+    let output = render_to_string(&session, Some(&best_status), Some(&best_records));
+
+    assert!(output.contains("BEST RECORDS"));
+    assert!(output.contains("Today's Best"));
+    assert!(output.contains("Weekly Best"));
+    assert!(output.contains("All time Best"));
+    assert!(output.contains("NEW PB"));
+    assert!(output.contains("(+50)"));
+    assert!(output.contains("(-20)"));
+    assert!(output.contains("(+20)"));
+}
+
+#[test]
+fn render_falls_back_to_score_comparison_when_no_status() {
+    let mut session = SessionResult::new();
+    session.session_score = 250.0;
+
+    let best_records = BestRecords {
+        todays_best: Some(sample_result(100.0, 300.0, 95.0)),
+        weekly_best: Some(sample_result(250.0, 320.0, 96.0)),
+        all_time_best: Some(sample_result(400.0, 340.0, 97.0)),
+    };
+
+    let output = render_to_string(&session, None, Some(&best_records));
+
+    assert!(output.contains("BEST RECORDS"));
+    assert!(output.contains("NEW PB"));
+    assert!(output.contains("(+150)"));
+    assert!(output.contains("(-150)"));
+}
+
+#[test]
+fn render_handles_missing_records_with_placeholder() {
+    let session = SessionResult::new();
+
+    let best_records = BestRecords {
+        todays_best: None,
+        weekly_best: None,
+        all_time_best: None,
+    };
+
+    let output = render_to_string(&session, None, Some(&best_records));
+
+    assert!(output.contains("BEST RECORDS"));
+    assert!(output.contains("No previous record"));
+}

--- a/tests/unit/presentation/tui/mod.rs
+++ b/tests/unit/presentation/tui/mod.rs
@@ -1,3 +1,4 @@
+pub mod best_records_view_tests;
 pub mod difficulty_selection_view_tests;
 pub mod score_view_tests;
 pub mod screen_manager_tests;

--- a/tests/unit/presentation/tui/mod.rs
+++ b/tests/unit/presentation/tui/mod.rs
@@ -1,5 +1,6 @@
 pub mod best_records_view_tests;
 pub mod difficulty_selection_view_tests;
+pub mod records_screen_tests;
 pub mod score_view_tests;
 pub mod screen_manager_tests;
 pub mod screen_trait_tests;

--- a/tests/unit/presentation/tui/records_screen_tests.rs
+++ b/tests/unit/presentation/tui/records_screen_tests.rs
@@ -1,0 +1,193 @@
+use chrono::Utc;
+use gittype::domain::events::EventBus;
+use gittype::domain::models::color_mode::ColorMode;
+use gittype::domain::models::storage::{SessionResultData, StoredRepository, StoredSession};
+use gittype::domain::models::theme::Theme;
+use gittype::domain::services::session_service::{SessionDisplayData, SessionServiceInterface};
+use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
+use gittype::presentation::tui::screens::records_screen::{
+    DateFilter, FilterState, RecordsAction, RecordsScreen, RecordsScreenData, SortBy,
+};
+use gittype::Result;
+use std::sync::Arc;
+
+struct StubSessionService;
+
+impl SessionServiceInterface for StubSessionService {
+    fn get_sessions_with_display_data(
+        &self,
+        _repository_filter: Option<i64>,
+        _date_filter_days: Option<i64>,
+        _sort_by: &str,
+        _sort_descending: bool,
+    ) -> Result<Vec<SessionDisplayData>> {
+        Ok(vec![])
+    }
+
+    fn get_all_repositories(&self) -> Result<Vec<StoredRepository>> {
+        Ok(vec![])
+    }
+}
+
+fn make_screen() -> RecordsScreen {
+    let event_bus = Arc::new(EventBus::new());
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let session_service = Arc::new(StubSessionService) as Arc<dyn SessionServiceInterface>;
+    RecordsScreen::new(event_bus, theme_service, session_service)
+}
+
+fn make_session(id: i64, repo_id: Option<i64>) -> SessionDisplayData {
+    SessionDisplayData {
+        session: StoredSession {
+            id,
+            repository_id: repo_id,
+            started_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            branch: None,
+            commit_hash: None,
+            is_dirty: false,
+            game_mode: "default".to_string(),
+            difficulty_level: None,
+            max_stages: None,
+            time_limit_seconds: None,
+        },
+        repository: None,
+        session_result: Some(SessionResultData {
+            keystrokes: 100,
+            mistakes: 5,
+            duration_ms: 30000,
+            wpm: 60.0,
+            cpm: 300.0,
+            accuracy: 95.0,
+            stages_completed: 3,
+            stages_attempted: 3,
+            stages_skipped: 0,
+            score: 800.0,
+            rank_name: None,
+            tier_name: None,
+            rank_position: None,
+            rank_total: None,
+            position: None,
+            total: None,
+        }),
+    }
+}
+
+// SortBy ---------------------------------------------------------------------
+
+#[test]
+fn sort_by_display_name_covers_all_variants() {
+    assert_eq!(SortBy::Date.display_name(), "Date");
+    assert_eq!(SortBy::Performance.display_name(), "Score");
+    assert_eq!(SortBy::Repository.display_name(), "Repository");
+    assert_eq!(SortBy::Duration.display_name(), "Duration");
+}
+
+#[test]
+fn sort_by_to_string_covers_all_variants() {
+    assert_eq!(SortBy::Date.to_string(), "date");
+    assert_eq!(SortBy::Performance.to_string(), "score");
+    assert_eq!(SortBy::Repository.to_string(), "repository");
+    assert_eq!(SortBy::Duration.to_string(), "duration");
+}
+
+#[test]
+fn sort_by_clone_and_eq() {
+    let s = SortBy::Performance;
+    let cloned = s.clone();
+    assert_eq!(s, cloned);
+    assert_ne!(SortBy::Date, SortBy::Performance);
+}
+
+// DateFilter -----------------------------------------------------------------
+
+#[test]
+fn date_filter_display_name_covers_all_variants() {
+    assert_eq!(DateFilter::All.display_name(), "All Time");
+    assert_eq!(DateFilter::Last7Days.display_name(), "Last 7 days");
+    assert_eq!(DateFilter::Last30Days.display_name(), "Last 30 days");
+    assert_eq!(DateFilter::Last90Days.display_name(), "Last 90 days");
+}
+
+#[test]
+fn date_filter_to_days_covers_all_variants() {
+    assert_eq!(DateFilter::All.to_days(), None);
+    assert_eq!(DateFilter::Last7Days.to_days(), Some(7));
+    assert_eq!(DateFilter::Last30Days.to_days(), Some(30));
+    assert_eq!(DateFilter::Last90Days.to_days(), Some(90));
+}
+
+#[test]
+fn date_filter_clone_and_eq() {
+    let f = DateFilter::Last30Days;
+    let cloned = f.clone();
+    assert_eq!(f, cloned);
+    assert_ne!(DateFilter::All, DateFilter::Last7Days);
+}
+
+// FilterState ----------------------------------------------------------------
+
+#[test]
+fn filter_state_default_matches_documented_defaults() {
+    let state = FilterState::default();
+    assert!(state.repository_filter.is_none());
+    assert_eq!(state.date_filter, DateFilter::Last30Days);
+    assert_eq!(state.sort_by, SortBy::Date);
+    assert!(state.sort_descending);
+}
+
+// RecordsAction --------------------------------------------------------------
+
+#[test]
+fn records_action_view_details_carries_session_id() {
+    let action = RecordsAction::ViewDetails(42);
+    let cloned = action.clone();
+    assert!(matches!(cloned, RecordsAction::ViewDetails(42)));
+}
+
+#[test]
+fn records_action_return_clone_preserves_variant() {
+    let action = RecordsAction::Return;
+    let cloned = action.clone();
+    assert!(matches!(cloned, RecordsAction::Return));
+}
+
+// RecordsScreenData ----------------------------------------------------------
+
+#[test]
+fn records_screen_data_holds_sessions_and_repositories() {
+    let sessions = vec![make_session(1, None)];
+    let repositories = vec![StoredRepository {
+        id: 5,
+        user_name: "alice".to_string(),
+        repository_name: "tools".to_string(),
+        remote_url: "https://example.com/alice/tools".to_string(),
+    }];
+    let data = RecordsScreenData {
+        sessions,
+        repositories,
+    };
+
+    assert_eq!(data.sessions.len(), 1);
+    assert_eq!(data.repositories.len(), 1);
+    assert_eq!(data.repositories[0].user_name, "alice");
+}
+
+// RecordsScreen --------------------------------------------------------------
+
+#[test]
+fn new_screen_starts_with_no_selected_session_or_action() {
+    let screen = make_screen();
+    assert!(screen.get_selected_session_for_detail().is_none());
+    assert!(screen.get_action_result().is_none());
+}
+
+#[test]
+fn set_selected_session_from_index_with_out_of_bounds_does_nothing() {
+    let screen = make_screen();
+    screen.set_selected_session_from_index(99);
+    assert!(screen.get_selected_session_for_detail().is_none());
+}

--- a/tests/unit/presentation/tui/records_screen_tests.rs
+++ b/tests/unit/presentation/tui/records_screen_tests.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
-use gittype::domain::events::EventBus;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use gittype::domain::events::presentation_events::NavigateTo;
+use gittype::domain::events::{EventBus, EventBusInterface};
 use gittype::domain::models::color_mode::ColorMode;
 use gittype::domain::models::storage::{SessionResultData, StoredRepository, StoredSession};
 use gittype::domain::models::theme::Theme;
@@ -8,8 +10,11 @@ use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterfa
 use gittype::presentation::tui::screens::records_screen::{
     DateFilter, FilterState, RecordsAction, RecordsScreen, RecordsScreenData, SortBy,
 };
-use gittype::Result;
-use std::sync::Arc;
+use gittype::presentation::tui::{Screen, ScreenType};
+use gittype::{GitTypeError, Result};
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use std::sync::{Arc, Mutex};
 
 struct StubSessionService;
 
@@ -29,14 +34,81 @@ impl SessionServiceInterface for StubSessionService {
     }
 }
 
+struct FailingSessionService;
+
+impl SessionServiceInterface for FailingSessionService {
+    fn get_sessions_with_display_data(
+        &self,
+        _repository_filter: Option<i64>,
+        _date_filter_days: Option<i64>,
+        _sort_by: &str,
+        _sort_descending: bool,
+    ) -> Result<Vec<SessionDisplayData>> {
+        Err(GitTypeError::TerminalError(
+            "stub sessions failure".to_string(),
+        ))
+    }
+
+    fn get_all_repositories(&self) -> Result<Vec<StoredRepository>> {
+        Err(GitTypeError::TerminalError(
+            "stub repos failure".to_string(),
+        ))
+    }
+}
+
 fn make_screen() -> RecordsScreen {
+    make_screen_with(StubSessionService)
+}
+
+fn make_screen_with<S: SessionServiceInterface + 'static>(service: S) -> RecordsScreen {
     let event_bus = Arc::new(EventBus::new());
     let theme_service = Arc::new(ThemeService::new_for_test(
         Theme::default(),
         ColorMode::Dark,
     )) as Arc<dyn ThemeServiceInterface>;
-    let session_service = Arc::new(StubSessionService) as Arc<dyn SessionServiceInterface>;
+    let session_service = Arc::new(service) as Arc<dyn SessionServiceInterface>;
     RecordsScreen::new(event_bus, theme_service, session_service)
+}
+
+fn make_screen_with_event_capture() -> (RecordsScreen, Arc<Mutex<Vec<NavigateTo>>>) {
+    let event_bus = Arc::new(EventBus::new());
+    let captured: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = Arc::clone(&captured);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        captured_clone.lock().unwrap().push(event.clone());
+    });
+    let theme_service = Arc::new(ThemeService::new_for_test(
+        Theme::default(),
+        ColorMode::Dark,
+    )) as Arc<dyn ThemeServiceInterface>;
+    let session_service = Arc::new(StubSessionService) as Arc<dyn SessionServiceInterface>;
+    let event_bus_dyn: Arc<dyn EventBusInterface> = event_bus;
+    let screen = RecordsScreen::new(event_bus_dyn, theme_service, session_service);
+    (screen, captured)
+}
+
+fn make_screen_data(num_sessions: usize) -> RecordsScreenData {
+    let sessions = (0..num_sessions)
+        .map(|i| make_session(i as i64, None))
+        .collect();
+    RecordsScreenData {
+        sessions,
+        repositories: Vec::new(),
+    }
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::empty())
+}
+
+fn render_screen(screen: &RecordsScreen) {
+    let backend = TestBackend::new(120, 30);
+    let mut terminal = Terminal::new(backend).expect("test backend should construct");
+    terminal
+        .draw(|frame| {
+            screen.render_ratatui(frame).expect("render should succeed");
+        })
+        .expect("draw should succeed");
 }
 
 fn make_session(id: i64, repo_id: Option<i64>) -> SessionDisplayData {
@@ -190,4 +262,347 @@ fn set_selected_session_from_index_with_out_of_bounds_does_nothing() {
     let screen = make_screen();
     screen.set_selected_session_from_index(99);
     assert!(screen.get_selected_session_for_detail().is_none());
+}
+
+// init_with_data ------------------------------------------------------------
+
+#[test]
+fn init_with_data_uses_screen_data_when_downcast_succeeds() {
+    let screen = make_screen();
+    let data = make_screen_data(3);
+
+    screen.init_with_data(Box::new(data)).unwrap();
+    screen.set_selected_session_from_index(2);
+
+    let selected = screen.get_selected_session_for_detail().unwrap();
+    assert_eq!(selected.session.id, 2);
+}
+
+#[test]
+fn init_with_data_falls_back_to_service_when_downcast_fails() {
+    let screen = make_screen();
+
+    let result = screen.init_with_data(Box::new(()));
+
+    assert!(result.is_ok());
+    screen.set_selected_session_from_index(0);
+    assert!(screen.get_selected_session_for_detail().is_none());
+}
+
+#[test]
+fn init_with_data_falls_back_to_failing_service_returns_error() {
+    let screen = make_screen_with(FailingSessionService);
+
+    let result = screen.init_with_data(Box::new(()));
+
+    assert!(result.is_err());
+}
+
+// Key handling --------------------------------------------------------------
+
+#[test]
+fn esc_publishes_navigate_to_title_and_records_return_action() {
+    let (screen, captured) = make_screen_with_event_capture();
+
+    screen.handle_key_event(key(KeyCode::Esc)).unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(matches!(
+        events.first(),
+        Some(NavigateTo::Replace(ScreenType::Title))
+    ));
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(RecordsAction::Return)
+    ));
+}
+
+#[test]
+fn ctrl_c_publishes_navigate_exit_and_records_return_action() {
+    let (screen, captured) = make_screen_with_event_capture();
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(matches!(events.first(), Some(NavigateTo::Exit)));
+    assert!(matches!(
+        screen.get_action_result(),
+        Some(RecordsAction::Return)
+    ));
+}
+
+#[test]
+fn enter_with_loaded_sessions_pushes_session_detail() {
+    let (screen, captured) = make_screen_with_event_capture();
+    screen
+        .init_with_data(Box::new(make_screen_data(2)))
+        .unwrap();
+
+    screen.handle_key_event(key(KeyCode::Enter)).unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(matches!(
+        events.first(),
+        Some(NavigateTo::Push(ScreenType::SessionDetail))
+    ));
+    assert!(screen.get_selected_session_for_detail().is_some());
+}
+
+#[test]
+fn space_with_loaded_sessions_pushes_session_detail() {
+    let (screen, captured) = make_screen_with_event_capture();
+    screen
+        .init_with_data(Box::new(make_screen_data(2)))
+        .unwrap();
+
+    screen.handle_key_event(key(KeyCode::Char(' '))).unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(matches!(
+        events.first(),
+        Some(NavigateTo::Push(ScreenType::SessionDetail))
+    ));
+}
+
+#[test]
+fn enter_without_loaded_sessions_does_not_push() {
+    let (screen, captured) = make_screen_with_event_capture();
+    screen
+        .init_with_data(Box::new(make_screen_data(0)))
+        .unwrap();
+    // refresh resets list_state.selected() to None when sessions are empty
+    screen.handle_key_event(key(KeyCode::Char('r'))).unwrap();
+    screen.handle_key_event(key(KeyCode::Enter)).unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(events.is_empty());
+}
+
+#[test]
+fn down_then_up_keys_navigate_without_panic() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(3)))
+        .unwrap();
+
+    screen.handle_key_event(key(KeyCode::Down)).unwrap();
+    screen.handle_key_event(key(KeyCode::Char('j'))).unwrap();
+    screen.handle_key_event(key(KeyCode::Up)).unwrap();
+    screen.handle_key_event(key(KeyCode::Char('k'))).unwrap();
+}
+
+#[test]
+fn down_wraps_around_to_first_after_reaching_last_entry() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(3)))
+        .unwrap();
+
+    // Selection starts at 0 — drive Down four times: 0→1→2→0 (wrap)→1
+    (0..4).for_each(|_| screen.handle_key_event(key(KeyCode::Down)).unwrap());
+
+    screen.handle_key_event(key(KeyCode::Enter)).unwrap();
+    let selected = screen.get_selected_session_for_detail().unwrap();
+    assert_eq!(selected.session.id, 1);
+}
+
+#[test]
+fn up_wraps_around_to_last_entry_from_first() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(3)))
+        .unwrap();
+
+    screen.handle_key_event(key(KeyCode::Up)).unwrap();
+    screen.handle_key_event(key(KeyCode::Enter)).unwrap();
+
+    let selected = screen.get_selected_session_for_detail().unwrap();
+    assert_eq!(selected.session.id, 2);
+}
+
+#[test]
+fn refresh_after_empty_init_handles_navigation_from_none_selection() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(0)))
+        .unwrap();
+
+    screen.handle_key_event(key(KeyCode::Char('r'))).unwrap();
+    screen.handle_key_event(key(KeyCode::Down)).unwrap();
+    screen.handle_key_event(key(KeyCode::Up)).unwrap();
+}
+
+#[test]
+fn refresh_with_failing_service_does_not_panic() {
+    let screen = make_screen_with(FailingSessionService);
+    screen.handle_key_event(key(KeyCode::Char('r'))).unwrap();
+}
+
+#[test]
+fn unhandled_key_event_does_not_publish_navigation() {
+    let (screen, captured) = make_screen_with_event_capture();
+
+    screen.handle_key_event(key(KeyCode::Char('z'))).unwrap();
+
+    assert!(captured.lock().unwrap().is_empty());
+}
+
+// Cycle sort and filter -----------------------------------------------------
+
+#[test]
+fn s_key_cycles_through_all_sort_variants_and_toggles_direction() {
+    let screen = make_screen();
+
+    // Initial: Date / descending=true
+    // s: Date → Performance
+    screen.handle_key_event(key(KeyCode::Char('s'))).unwrap();
+    // s: Performance → Repository
+    screen.handle_key_event(key(KeyCode::Char('s'))).unwrap();
+    // s: Repository → Duration
+    screen.handle_key_event(key(KeyCode::Char('s'))).unwrap();
+    // s: Duration → Date (toggles descending to false)
+    screen.handle_key_event(key(KeyCode::Char('s'))).unwrap();
+    // s: Date → Performance again (no toggle this time)
+    screen.handle_key_event(key(KeyCode::Char('s'))).unwrap();
+}
+
+#[test]
+fn f_key_cycles_through_all_date_filter_variants() {
+    let screen = make_screen();
+
+    // Initial: Last30Days
+    // f: Last30Days → Last90Days
+    screen.handle_key_event(key(KeyCode::Char('f'))).unwrap();
+    // f: Last90Days → All
+    screen.handle_key_event(key(KeyCode::Char('f'))).unwrap();
+    // f: All → Last7Days
+    screen.handle_key_event(key(KeyCode::Char('f'))).unwrap();
+    // f: Last7Days → Last30Days
+    screen.handle_key_event(key(KeyCode::Char('f'))).unwrap();
+}
+
+#[test]
+fn f_key_with_loaded_sessions_resets_selection_to_first() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(3)))
+        .unwrap();
+    screen.handle_key_event(key(KeyCode::Down)).unwrap();
+
+    // 'f' resets selection back to Some(0) since stub returns empty + then non-empty?
+    // Here we just confirm the call does not error.
+    screen.handle_key_event(key(KeyCode::Char('f'))).unwrap();
+}
+
+#[test]
+fn s_and_f_key_with_failing_service_do_not_panic() {
+    let screen = make_screen_with(FailingSessionService);
+
+    screen.handle_key_event(key(KeyCode::Char('s'))).unwrap();
+    screen.handle_key_event(key(KeyCode::Char('f'))).unwrap();
+}
+
+// Rendering -----------------------------------------------------------------
+
+#[test]
+fn render_with_empty_sessions_shows_empty_message() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(0)))
+        .unwrap();
+    // Empty state results when refresh sets list_state.select(None)
+    screen.handle_key_event(key(KeyCode::Char('r'))).unwrap();
+
+    render_screen(&screen);
+}
+
+#[test]
+fn render_with_loaded_sessions_renders_list() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(3)))
+        .unwrap();
+
+    render_screen(&screen);
+}
+
+#[test]
+fn render_with_session_missing_repository_and_result_renders_placeholders() {
+    let screen = make_screen();
+
+    let mut session = make_session(1, None);
+    session.repository = None;
+    session.session_result = None;
+
+    let data = RecordsScreenData {
+        sessions: vec![session],
+        repositories: Vec::new(),
+    };
+    screen.init_with_data(Box::new(data)).unwrap();
+
+    render_screen(&screen);
+}
+
+#[test]
+fn render_with_long_repository_name_truncates() {
+    let screen = make_screen();
+
+    let mut session = make_session(1, Some(1));
+    session.repository = Some(StoredRepository {
+        id: 1,
+        user_name: "very-very-very-long-user".to_string(),
+        repository_name: "and-an-incredibly-long-repository-name".to_string(),
+        remote_url: "https://example.com/x/y".to_string(),
+    });
+
+    let data = RecordsScreenData {
+        sessions: vec![session],
+        repositories: Vec::new(),
+    };
+    screen.init_with_data(Box::new(data)).unwrap();
+
+    render_screen(&screen);
+}
+
+#[test]
+fn render_with_ascending_sort_renders_arrow() {
+    let screen = make_screen();
+    screen
+        .init_with_data(Box::new(make_screen_data(2)))
+        .unwrap();
+
+    // Cycle sort 4 times so we end up back on Date with sort_descending=false.
+    (0..4).for_each(|_| screen.handle_key_event(key(KeyCode::Char('s'))).unwrap());
+
+    render_screen(&screen);
+}
+
+// Screen trait misc ---------------------------------------------------------
+
+#[test]
+fn cleanup_returns_ok() {
+    let screen = make_screen();
+    assert!(screen.cleanup().is_ok());
+}
+
+#[test]
+fn as_any_downcasts_to_concrete_type() {
+    let screen = make_screen();
+    assert!(screen.as_any().downcast_ref::<RecordsScreen>().is_some());
+}
+
+#[test]
+fn filter_state_struct_fields_are_accessible() {
+    let state = FilterState {
+        repository_filter: Some(7),
+        date_filter: DateFilter::Last7Days,
+        sort_by: SortBy::Repository,
+        sort_descending: false,
+    };
+    assert_eq!(state.repository_filter, Some(7));
+    assert_eq!(state.date_filter, DateFilter::Last7Days);
+    assert_eq!(state.sort_by, SortBy::Repository);
+    assert!(!state.sort_descending);
 }

--- a/tests/unit/presentation/tui/screen_transition_manager_tests.rs
+++ b/tests/unit/presentation/tui/screen_transition_manager_tests.rs
@@ -589,4 +589,114 @@ mod tests {
         .unwrap();
         assert_eq!(result, ScreenType::SessionFailure);
     }
+
+    // === Side-effect handler branches when SessionManagerInterface
+    //     is NOT the concrete SessionManager (downcast returns None) ===
+
+    struct FakeSessionManager;
+
+    impl SessionManagerInterface for FakeSessionManager {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn fake_session_manager() -> Arc<dyn SessionManagerInterface> {
+        Arc::new(FakeSessionManager)
+    }
+
+    #[test]
+    fn test_title_to_typing_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::Title, ScreenType::Typing, &sm).unwrap();
+        assert_eq!(result, ScreenType::Typing);
+    }
+
+    #[test]
+    fn test_session_failure_to_typing_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::SessionFailure, ScreenType::Typing, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::Typing);
+    }
+
+    #[test]
+    fn test_typing_to_session_failure_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::Typing, ScreenType::SessionFailure, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::SessionFailure);
+    }
+
+    #[test]
+    fn test_stage_summary_to_session_failure_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result = ScreenTransitionManager::reduce(
+            ScreenType::StageSummary,
+            ScreenType::SessionFailure,
+            &sm,
+        )
+        .unwrap();
+        assert_eq!(result, ScreenType::SessionFailure);
+    }
+
+    #[test]
+    fn test_typing_to_animation_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::Typing, ScreenType::Animation, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::Animation);
+    }
+
+    #[test]
+    fn test_stage_summary_to_animation_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::StageSummary, ScreenType::Animation, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::Animation);
+    }
+
+    #[test]
+    fn test_session_summary_to_typing_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::SessionSummary, ScreenType::Typing, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::Typing);
+    }
+
+    #[test]
+    fn test_session_summary_to_title_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::SessionSummary, ScreenType::Title, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::Title);
+    }
+
+    #[test]
+    fn test_session_failure_to_title_with_non_concrete_session_manager_is_noop() {
+        let sm = fake_session_manager();
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::SessionFailure, ScreenType::Title, &sm)
+                .unwrap();
+        assert_eq!(result, ScreenType::Title);
+    }
+
+    // === Title→Typing when session is already in progress (skip-start branch) ===
+
+    #[test]
+    fn test_title_to_typing_when_session_already_in_progress_skips_start() {
+        let sm = create_session_manager();
+        start_session(&sm);
+        // Second Title→Typing transition: sm.is_in_progress() is true → Start is skipped.
+        let result =
+            ScreenTransitionManager::reduce(ScreenType::Title, ScreenType::Typing, &sm).unwrap();
+        assert_eq!(result, ScreenType::Typing);
+    }
 }

--- a/tests/unit/presentation/tui/total_summary_share_screen_tests.rs
+++ b/tests/unit/presentation/tui/total_summary_share_screen_tests.rs
@@ -1,4 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use gittype::domain::events::presentation_events::NavigateTo;
 use gittype::domain::events::EventBus;
 use gittype::domain::events::EventBusInterface;
 use gittype::domain::models::color_mode::ColorMode;
@@ -6,10 +7,14 @@ use gittype::domain::models::theme::Theme;
 use gittype::domain::models::TotalResult;
 use gittype::domain::services::scoring::{TotalTracker, TotalTrackerInterface};
 use gittype::domain::services::theme_service::{ThemeService, ThemeServiceInterface};
+use gittype::presentation::di::AppModule;
 use gittype::presentation::sharing::SharingPlatform;
-use gittype::presentation::tui::screens::total_summary_share_screen::TotalSummaryShareScreen;
+use gittype::presentation::tui::screens::total_summary_share_screen::{
+    TotalSummaryShareScreen, TotalSummaryShareScreenProvider,
+};
 use gittype::presentation::tui::Screen;
-use std::sync::Arc;
+use shaku::Provider;
+use std::sync::{Arc, Mutex};
 
 fn make_screen() -> TotalSummaryShareScreen {
     TotalSummaryShareScreen::new(
@@ -67,4 +72,96 @@ fn escape_clears_fallback_url_before_navigating_back() {
         .unwrap();
 
     assert!(screen.fallback_url_for_test().is_none());
+}
+
+#[test]
+fn provider_resolves_screen_from_app_module() {
+    let module = AppModule::builder().build();
+    let provided = <TotalSummaryShareScreenProvider as Provider<AppModule>>::provide(&module);
+
+    assert!(provided.is_ok());
+}
+
+#[test]
+fn escape_without_fallback_publishes_pop_navigation() {
+    let event_bus = Arc::new(EventBus::new());
+    let captured: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+    let observed = Arc::clone(&captured);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed.lock().unwrap().push(event.clone());
+    });
+
+    let screen = TotalSummaryShareScreen::new(
+        event_bus.clone() as Arc<dyn EventBusInterface>,
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+        Arc::new(TotalTracker::new_for_test()) as Arc<dyn TotalTrackerInterface>,
+    );
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
+        .unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(matches!(events.as_slice(), [NavigateTo::Pop]));
+}
+
+#[test]
+fn ctrl_c_publishes_exit_navigation() {
+    let event_bus = Arc::new(EventBus::new());
+    let captured: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+    let observed = Arc::clone(&captured);
+    event_bus.subscribe(move |event: &NavigateTo| {
+        observed.lock().unwrap().push(event.clone());
+    });
+
+    let screen = TotalSummaryShareScreen::new(
+        event_bus.clone() as Arc<dyn EventBusInterface>,
+        Arc::new(ThemeService::new_for_test(
+            Theme::default(),
+            ColorMode::Dark,
+        )) as Arc<dyn ThemeServiceInterface>,
+        Arc::new(TotalTracker::new_for_test()) as Arc<dyn TotalTrackerInterface>,
+    );
+
+    screen
+        .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .unwrap();
+
+    let events = captured.lock().unwrap();
+    assert!(matches!(events.as_slice(), [NavigateTo::Exit]));
+}
+
+#[test]
+fn share_platform_keys_publish_pop_when_browser_opens() {
+    for key in ['1', '2', '3', '4'] {
+        let event_bus = Arc::new(EventBus::new());
+        let captured: Arc<Mutex<Vec<NavigateTo>>> = Arc::new(Mutex::new(Vec::new()));
+        let observed = Arc::clone(&captured);
+        event_bus.subscribe(move |event: &NavigateTo| {
+            observed.lock().unwrap().push(event.clone());
+        });
+
+        let screen = TotalSummaryShareScreen::new(
+            event_bus.clone() as Arc<dyn EventBusInterface>,
+            Arc::new(ThemeService::new_for_test(
+                Theme::default(),
+                ColorMode::Dark,
+            )) as Arc<dyn ThemeServiceInterface>,
+            Arc::new(TotalTracker::new_for_test()) as Arc<dyn TotalTrackerInterface>,
+        );
+
+        screen
+            .handle_key_event(KeyEvent::new(KeyCode::Char(key), KeyModifiers::empty()))
+            .unwrap();
+
+        let events = captured.lock().unwrap();
+        assert!(
+            matches!(events.as_slice(), [NavigateTo::Pop]),
+            "key {key} should publish Pop, got {:?}",
+            *events
+        );
+    }
 }


### PR DESCRIPTION
Autonomous kobito run to incrementally raise overall line coverage.

This iteration measures the baseline via `cargo llvm-cov --workspace --summary-only`, picks one under-covered target, and adds tests-only changes that strictly increase the overall line percentage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration and unit tests across UI screens, domain services, and repositories.
  * Extended test coverage for multiple programming language parsers.
  * Improved database testing with new migration and data access object tests.
  * Added test-only accessor methods to support enhanced testing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/gittype/pull/424)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->