### PR TITLE
docs: add Support section with star and share links

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ Prefer watching code over typing it? Check out [**Gitlogue**](https://github.com
 If you find this project useful, please consider:
 
 - ⭐️ [Star on GitHub](https://github.com/unhappychoice/gittype)
-- 🐦 [Share on X](https://x.com/intent/post?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE&url=https%3A//github.com/unhappychoice/gittype&hashtags=gittype)
-- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE%20%23gittype%20https%3A//github.com/unhappychoice/gittype)
-- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE%20%23gittype%20https%3A//github.com/unhappychoice/gittype)
+- 🐦 [Share on X](https://x.com/intent/post?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE&url=https%3A//github.com/unhappychoice/gittype&hashtags=gittype,CLI,Rust,typing)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE%20%23gittype%20%23CLI%20%23Rust%20%23typing%20https%3A//github.com/unhappychoice/gittype)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE%20%23gittype%20%23CLI%20%23Rust%20%23typing%20https%3A//github.com/unhappychoice/gittype)
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/gittype)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/gittype)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/gittype&t=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE)

--- a/README.md
+++ b/README.md
@@ -164,3 +164,17 @@ Prefer watching code over typing it? Check out [**Gitlogue**](https://github.com
 ## Author
 
 [@unhappychoice](https://unhappychoice.com)
+
+## Support
+
+If you find this project useful, please consider:
+
+- ⭐️ [Star on GitHub](https://github.com/unhappychoice/gittype)
+- 🐦 [Share on X](https://x.com/intent/post?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE&url=https%3A//github.com/unhappychoice/gittype&hashtags=gittype)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE%20%23gittype%20https%3A//github.com/unhappychoice/gittype)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE%20%23gittype%20https%3A//github.com/unhappychoice/gittype)
+- 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/gittype)
+- 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/gittype)
+- 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/gittype&t=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE)
+
+Every bit of support helps. Thanks!

--- a/README.md
+++ b/README.md
@@ -176,5 +176,7 @@ If you find this project useful, please consider:
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/gittype)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/gittype)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/gittype&t=gittype%3A%20a%20CLI%20typing%20game%20that%20uses%20your%20own%20source%20code%20as%20practice%20text%20%F0%9F%8E%AE)
+- 💬 Drop it into your Discord server or developer chat
+- ✍️ Write about it on your blog or in a newsletter
 
 Every bit of support helps. Thanks!


### PR DESCRIPTION
## Summary

- Add a Support section at the end of README with links to star the repo and share it on X, Bluesky, Threads, LinkedIn, Facebook, and Hacker News.
- Each share link is pre-filled with a short pitch and the `#gittype` hashtag where supported.

## Test plan

- [x] README renders correctly on GitHub
- [ ] Each share link opens the target platform's composer with the expected text and URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Support” section guiding readers how to engage with the project.
  * Added calls to action to star the repo and share across social platforms (X, Bluesky, Threads, LinkedIn, Facebook) and to submit to Hacker News.
  * Ends with brief suggestions for sharing in chats/blogs and a short thank-you message encouraging community support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/gittype/pull/427)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->