### PR TITLE
fix(nix): use rust-overlay's latest stable for unstable package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,14 @@
           doCheck = false;
         };
 
-        unstable = pkgs.rustPlatform.buildRustPackage rec {
+        unstable = let
+          rustToolchain = pkgs.rust-bin.stable.latest.default;
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          };
+        in
+        rustPlatform.buildRustPackage rec {
           inherit pname version;
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;


### PR DESCRIPTION
## Summary

- The `unstable` flake package built via `pkgs.rustPlatform.buildRustPackage`, which uses nixpkgs' default rustc (currently 1.89.0)
- Recent dependency upgrades fail to compile under 1.89 because they rely on features stabilized later (e.g. `libsqlite3-sys 0.38.0` uses `cfg_select!`, stabilized in Rust 1.91)
- Switch the `unstable` package to `rust-overlay`'s `stable.latest` toolchain via `makeRustPlatform` so Nix CI keeps up with dependency upgrades

This unblocks PR #433 (rusqlite 0.39 → 0.40), whose only failing check is Nix Build.

## Test plan

- [ ] CI's `Nix Build` job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use an explicitly pinned Rust toolchain version for improved build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->