### PR TITLE
chore(deps): bump git2 from 0.20 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,17 +1112,15 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
  "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -1775,13 +1773,12 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1804,20 +1801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -2122,12 +2105,6 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -2844,7 +2821,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ once_cell = "1.21"
 rayon = "1.12"
 open = "5.3"
 urlencoding = "2.1"
-git2 = { version = "0.20", features = ["vendored-openssl", "vendored-libgit2"] }
+git2 = { version = "0.21", features = ["vendored-openssl", "vendored-libgit2"] }
 streaming-iterator = "0.1"
 log = "0.4"
 log4rs = "1.4"

--- a/src/infrastructure/git/local/local_git_repository_client.rs
+++ b/src/infrastructure/git/local/local_git_repository_client.rs
@@ -77,27 +77,21 @@ impl LocalGitRepositoryClient {
     }
 
     fn get_remote_url(&self, repo: &Repository) -> Result<String> {
-        repo.find_remote("origin")
-            .map_err(|e| {
-                GitTypeError::ExtractionFailed(format!("Failed to find origin remote: {}", e))
-            })
-            .map(|remote| remote.url().map(str::to_string))
-            .and_then(|url_opt| {
-                url_opt.ok_or_else(|| {
-                    GitTypeError::ExtractionFailed("Remote URL is not valid UTF-8".to_string())
-                })
-            })
+        let remote = repo.find_remote("origin").map_err(|e| {
+            GitTypeError::ExtractionFailed(format!("Failed to find origin remote: {}", e))
+        })?;
+        remote.url().map(String::from).map_err(|e| {
+            GitTypeError::ExtractionFailed(format!("Remote URL is not valid UTF-8: {}", e))
+        })
     }
 
     fn get_current_branch(&self, repo: &Repository) -> Result<String> {
-        repo.head()
-            .map_err(|e| GitTypeError::ExtractionFailed(format!("Failed to get HEAD: {}", e)))
-            .map(|head| head.shorthand().map(str::to_string))
-            .and_then(|name_opt| {
-                name_opt.ok_or_else(|| {
-                    GitTypeError::ExtractionFailed("Branch name is not valid UTF-8".to_string())
-                })
-            })
+        let head = repo
+            .head()
+            .map_err(|e| GitTypeError::ExtractionFailed(format!("Failed to get HEAD: {}", e)))?;
+        head.shorthand().map(String::from).map_err(|e| {
+            GitTypeError::ExtractionFailed(format!("Branch name is not valid UTF-8: {}", e))
+        })
     }
 
     fn get_current_commit_hash(&self, repo: &Repository) -> Result<String> {
@@ -128,9 +122,8 @@ impl LocalGitRepositoryClient {
         // Get remote URL (origin)
         let remote_url = repo
             .find_remote("origin")
-            .ok()
-            .and_then(|remote| remote.url().map(|s| s.to_string()))
-            .unwrap_or_else(|| format!("file://{}", path.display()));
+            .and_then(|remote| remote.url().map(String::from))
+            .unwrap_or_else(|_| format!("file://{}", path.display()));
 
         // Extract user_name and repository_name from path or URL
         let (user_name, repository_name) = if remote_url.starts_with("file://") {
@@ -150,8 +143,8 @@ impl LocalGitRepositoryClient {
         // Get current branch
         let branch = repo
             .head()
-            .ok()
-            .and_then(|head| head.shorthand().map(|s| s.to_string()));
+            .and_then(|head| head.shorthand().map(String::from))
+            .ok();
 
         // Get current commit hash
         let commit_hash = repo


### PR DESCRIPTION
## Summary

- Bumps `git2` from 0.20 to 0.21
- `Remote::url()` and `Reference::shorthand()` now return `Result<String, git2::Error>` instead of `Option<&str>` — rewrite the affected accessors in `LocalGitRepositoryClient` to propagate the new errors, and adapt the fallback branches in `create_from_local_path`

Supersedes #428 (which fails CI because Dependabot only bumps the version without applying the API changes).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test\` (2767 passed)
- [ ] CI passes on all jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `git2` dependency from version 0.20 to 0.21 while maintaining existing feature configurations.

* **Refactor**
  * Improved internal git repository information extraction logic for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->