### PR TITLE
feat: add winget package distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
+      new_version_no_v: ${{ steps.version.outputs.new_version_no_v }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       tag_sha: ${{ steps.tag_sha.outputs.tag_sha }}
     steps:
@@ -47,6 +48,7 @@ jobs:
           cargo set-version --bump ${{ github.event.inputs.version_type }}
           NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           echo "new_version=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version_no_v=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: v$NEW_VERSION"
 
       # Run tests before release
@@ -327,3 +329,17 @@ jobs:
           git add Formula/gittype.rb
           git commit -m "chore: update gittype to $VERSION"
           git push
+
+  update-winget:
+    name: Update WinGet Package
+    runs-on: ubuntu-latest
+    needs: [release, build-and-upload]
+    steps:
+      - name: Submit manifest to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: unhappychoice.gittype
+          version: ${{ needs.release.outputs.new_version_no_v }}
+          release-tag: ${{ needs.release.outputs.new_version }}
+          installers-regex: 'x86_64-pc-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.winget/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.installer.yaml
+++ b/.winget/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: unhappychoice.gittype
+PackageVersion: 0.10.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: gittype.exe
+    PortableCommandAlias: gittype
+Commands:
+  - gittype
+ReleaseDate: 2026-04-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/unhappychoice/gittype/releases/download/v0.10.0/gittype-v0.10.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 62E625B18AD860235BF9E1A618525FB20B7E0BFF5614D142E2803629D163A8B8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/.winget/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.locale.en-US.yaml
+++ b/.winget/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: unhappychoice.gittype
+PackageVersion: 0.10.0
+PackageLocale: en-US
+Publisher: unhappychoice
+PublisherUrl: https://github.com/unhappychoice
+PublisherSupportUrl: https://github.com/unhappychoice/gittype/issues
+PackageName: GitType
+PackageUrl: https://github.com/unhappychoice/gittype
+License: MIT
+LicenseUrl: https://github.com/unhappychoice/gittype/blob/main/LICENSE
+Copyright: Copyright (c) unhappychoice
+ShortDescription: A typing practice tool using your own code repositories
+Description: |-
+  GitType is a Rust CLI typing game that turns source code from real repositories
+  into typing challenges. It parses code with tree-sitter, renders a terminal UI,
+  tracks real-time WPM/accuracy/consistency metrics, and unlocks developer titles
+  through a ranking system. Multi-language support includes Rust, TypeScript,
+  JavaScript, Python, Go, Ruby, Swift, Kotlin, Java, PHP, C#, C, C++, Haskell,
+  Dart, Scala, Clojure, Elixir, Erlang, and Zig.
+Moniker: gittype
+Tags:
+  - cli
+  - code
+  - developer
+  - git
+  - practice
+  - terminal
+  - tui
+  - typing
+ReleaseNotesUrl: https://github.com/unhappychoice/gittype/releases/tag/v0.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/.winget/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.yaml
+++ b/.winget/manifests/u/unhappychoice/gittype/0.10.0/unhappychoice.gittype.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: unhappychoice.gittype
+PackageVersion: 0.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -449,6 +449,24 @@ pub fn extract_chunks(
 
 ---
 
+## Release Distribution
+
+GitType is distributed through several package managers. Most channels are updated automatically by the release workflow (`.github/workflows/release.yml`); a few require one-time setup.
+
+### winget (Windows)
+
+The release workflow submits a manifest PR to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) via [`vedantmgoyal9/winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser) on every release.
+
+**One-time setup:**
+
+1. The initial `0.10.0` manifest lives under `.winget/manifests/u/unhappychoice/gittype/0.10.0/` and must be PR'd manually to `microsoft/winget-pkgs` once. After it is merged, subsequent versions are added automatically.
+2. Create a fork of `microsoft/winget-pkgs` under the owner account.
+3. Create a GitHub PAT (classic) with `public_repo` scope that can push to the fork, and register it as the `WINGET_TOKEN` repository secret.
+
+**Package identifier:** `unhappychoice.gittype`
+
+---
+
 ## Getting Help
 
 - **Issues**: Browse existing issues or create a new one


### PR DESCRIPTION
## Summary

Adds Windows Package Manager (winget) distribution so Windows users can install GitType with `winget install unhappychoice.gittype`. Closes #434.

- New `update-winget` job in `release.yml` auto-submits a manifest PR to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) on every release via [`vedantmgoyal9/winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser), reusing the existing `x86_64-pc-windows-msvc.zip` release asset.
- Initial `0.10.0` manifest seeded under `.winget/manifests/u/unhappychoice/gittype/0.10.0/` (version + installer + locale). This needs to be PR'd to `microsoft/winget-pkgs` once manually; the automation takes over from the next release.
- One-time setup (fork of `microsoft/winget-pkgs`, `WINGET_TOKEN` PAT secret) is documented in `docs/CONTRIBUTING.md`.

## One-time setup checklist (before the next release)

- [ ] Fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) under `unhappychoice`.
- [ ] Submit the seeded `.winget/manifests/u/unhappychoice/gittype/0.10.0/` files as a PR to `microsoft/winget-pkgs` and wait for approval.
- [ ] Create a GitHub Personal Access Token (classic, `public_repo` scope) able to push to the fork, register as `WINGET_TOKEN` repository secret.

## Test plan

- [ ] Validate that the YAML manifests parse and reference the correct PackageIdentifier / PackageVersion (verified locally).
- [ ] After merging this PR, run the workflow that submits the initial manifest to `microsoft/winget-pkgs` and confirm it is accepted.
- [ ] On the first subsequent `Manual Release` run after the initial manifest is merged, confirm the `update-winget` job opens a PR with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitType is now available on Windows Package Manager (WinGet), making it easier for Windows users to install and keep the application updated through their preferred package manager.

* **Documentation**
  * Updated contributing documentation with information about the release distribution process and package manager publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->