### PR TITLE
fix(clippy): remove useless borrow in println! argument

### DIFF
--- a/tests/integration/comment_processing_tests.rs
+++ b/tests/integration/comment_processing_tests.rs
@@ -239,7 +239,7 @@ mod byte_char_position_bugs {
                             i,
                             start,
                             end,
-                            &display_text.chars().collect::<Vec<char>>()
+                            display_text.chars().collect::<Vec<char>>()
                                 [start..end.min(display_text.chars().count())]
                                 .iter()
                                 .collect::<String>()


### PR DESCRIPTION
## Summary
- Rust 1.97's `clippy::useless_borrows_in_formatting` now flags the leading `&` on the `Vec<char>` temporary passed to `println!("... {:?}", ...)` in `tests/integration/comment_processing_tests.rs` because the borrow is inserted implicitly for the format argument.
- Dropping the `&` unblocks `cargo clippy --all-targets --all-features -- -D warnings` on the current toolchain, which was failing on unrelated PRs (e.g. Dependabot #460).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected comment text extraction in an integration test to ensure comment ranges are processed accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->