### PR TITLE
fix: redraw TUI after terminal resize

### DIFF
--- a/src/presentation/tui/screen_manager.rs
+++ b/src/presentation/tui/screen_manager.rs
@@ -199,6 +199,11 @@ impl<B: ratatui::backend::Backend + Send + 'static> ScreenManagerImpl<B> {
         self.pending_transition.lock().unwrap().clone()
     }
 
+    #[cfg(feature = "test-mocks")]
+    pub fn handle_event_for_test(&mut self, event: Event) -> Result<()> {
+        self.handle_event(event)
+    }
+
     /// Set up event subscriptions for navigation events
     /// Takes a weak reference to avoid circular references
     pub fn setup_event_subscriptions(manager_ref: &Arc<Mutex<Self>>) {
@@ -662,34 +667,39 @@ impl<B: ratatui::backend::Backend + Send + 'static> ScreenManagerImpl<B> {
         };
 
         if poll(timeout)? {
-            if let Event::Key(key_event) = read()? {
-                if key_event.kind == KeyEventKind::Press {
-                    if key_event.modifiers.contains(KeyModifiers::CONTROL)
-                        && key_event.code == KeyCode::Char('c')
-                    {
-                        // Ctrl+C should either transition to ExitSummary or exit if already there
-                        if self.current_screen_type == ScreenType::TotalSummary {
-                            self.exit_requested = true;
-                        } else {
-                            let _ = self.handle_transition(ScreenTransition::Replace(
-                                ScreenType::TotalSummary,
-                            ));
-                        }
-                        return Ok(());
-                    }
-
-                    if let Some(screen) = self.screens.get_mut(&self.current_screen_type) {
-                        screen.handle_key_event(key_event)?;
-                    }
-
-                    // Always re-render on key input for ratatui screens
-                    // as they may have internal state changes (list selection, etc.)
-                    self.render_current_screen()?;
-                }
-            }
+            self.handle_event(read()?)?;
         }
 
         Ok(())
+    }
+
+    fn handle_event(&mut self, event: Event) -> Result<()> {
+        match event {
+            Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+                self.handle_key_input(key_event)
+            }
+            Event::Resize(_, _) => self.render_current_screen(),
+            _ => Ok(()),
+        }
+    }
+
+    fn handle_key_input(&mut self, key_event: crossterm::event::KeyEvent) -> Result<()> {
+        if key_event.modifiers.contains(KeyModifiers::CONTROL)
+            && key_event.code == KeyCode::Char('c')
+        {
+            if self.current_screen_type == ScreenType::TotalSummary {
+                self.exit_requested = true;
+            } else {
+                let _ = self.handle_transition(ScreenTransition::Replace(ScreenType::TotalSummary));
+            }
+            return Ok(());
+        }
+
+        if let Some(screen) = self.screens.get_mut(&self.current_screen_type) {
+            screen.handle_key_event(key_event)?;
+        }
+
+        self.render_current_screen()
     }
 
     pub fn render_current_screen(&mut self) -> Result<()> {

--- a/tests/unit/presentation/tui/screen_manager_tests.rs
+++ b/tests/unit/presentation/tui/screen_manager_tests.rs
@@ -1,4 +1,4 @@
-use crossterm::event::KeyEvent;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use gittype::domain::events::EventBus;
 use gittype::domain::services::scoring::{
     SessionTracker, SessionTrackerInterface, TotalTracker, TotalTrackerInterface,
@@ -23,6 +23,7 @@ use ratatui::Terminal;
 use shaku::HasComponent;
 use std::any::Any;
 use std::io::Stdout;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 // Mock TerminalInterface for testing
@@ -96,6 +97,10 @@ struct PushAwareScreen {
     pushed_from: Arc<Mutex<Option<ScreenType>>>,
 }
 
+struct RenderCountingScreen {
+    render_count: Arc<AtomicUsize>,
+}
+
 // Mock data provider for testing
 struct MockDataProvider;
 
@@ -123,6 +128,12 @@ impl PushAwareScreen {
             screen_type,
             pushed_from,
         }
+    }
+}
+
+impl RenderCountingScreen {
+    fn new(render_count: Arc<AtomicUsize>) -> Self {
+        Self { render_count }
     }
 }
 
@@ -251,6 +262,36 @@ impl Screen for PushAwareScreen {
 
     fn get_update_strategy(&self) -> UpdateStrategy {
         UpdateStrategy::InputOnly
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl Screen for RenderCountingScreen {
+    fn get_type(&self) -> ScreenType {
+        ScreenType::Title
+    }
+
+    fn default_provider() -> Box<dyn ScreenDataProvider>
+    where
+        Self: Sized,
+    {
+        Box::new(MockDataProvider)
+    }
+
+    fn init_with_data(&self, _data: Box<dyn Any>) -> gittype::Result<()> {
+        Ok(())
+    }
+
+    fn render_ratatui(&self, _frame: &mut Frame) -> gittype::Result<()> {
+        self.render_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn handle_key_event(&self, _key_event: KeyEvent) -> gittype::Result<()> {
+        Ok(())
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -468,6 +509,35 @@ fn test_render_current_screen_with_test_backend() {
     // because ratatui_terminal is None and it handles that case
     let result = manager.render_current_screen();
     assert!(result.is_ok());
+}
+
+#[test]
+fn test_resize_event_redraws_current_screen() {
+    let mut manager = create_test_screen_manager();
+    let render_count = Arc::new(AtomicUsize::new(0));
+    manager.register_screen(RenderCountingScreen::new(Arc::clone(&render_count)));
+
+    manager
+        .handle_event_for_test(Event::Resize(120, 40))
+        .unwrap();
+
+    assert_eq!(render_count.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_key_press_event_still_redraws_current_screen() {
+    let mut manager = create_test_screen_manager();
+    let render_count = Arc::new(AtomicUsize::new(0));
+    manager.register_screen(RenderCountingScreen::new(Arc::clone(&render_count)));
+
+    manager
+        .handle_event_for_test(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )))
+        .unwrap();
+
+    assert_eq!(render_count.load(Ordering::SeqCst), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Redraw the current screen when Crossterm reports a terminal resize event.
- Keep keypress handling behavior unchanged while separating terminal event dispatch from key input handling.
- Add regression tests for resize-triggered redraws and the existing keypress redraw path.

## Why

Resizing a terminal could leave GitType's TUI with a stale or broken layout until the user pressed another key. This is especially noticeable with tiling window managers, such as Hyprland on Arch Linux, where changing the layout, toggling fullscreen, or moving a terminal between tiled and floating states frequently changes its dimensions.

The event loop was already receiving Crossterm's `Event::Resize`, but it only handled keyboard events. The resize event was therefore consumed without scheduling a new frame. This affected input-only screens most clearly because they might not have another automatic render cycle.

The author's related Gitlogue TUI already remains responsive through the same window-manager resize workflow because its animation loop continuously checks the terminal dimensions and renders new frames. GitType's screens are primarily event-driven, so continuously redrawing them would perform unnecessary work. Handling Crossterm's `Event::Resize` gives GitType the same responsive behavior while rendering only when the terminal dimensions actually change.

## What changed

Terminal events now pass through a dedicated event handler. Key press events continue through the existing input path, while resize events immediately call `render_current_screen()`. Ratatui then redraws the active screen using the terminal's current dimensions.

The tests use `TestBackend` and a render-counting screen, so the behavior is verified without requiring a real TTY. One test confirms that a resize produces a redraw, and an adjacent regression test confirms that key presses still redraw as before.

The implementation is terminal- and window-manager-agnostic; Hyprland is a common way to encounter the problem, but the fix applies anywhere the terminal is resized.

## Testing

```text
cargo test test_resize_event_redraws_current_screen
cargo test screen_manager_tests
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
TMPDIR=/var/tmp cargo test
cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
```

The full test suite and coverage run completed with 2,769 passed and 14 ignored tests, plus the documentation test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured screen redraws occur exactly once after resize and key events.
  * Preserved existing behavior for key presses, screen dispatch, window resizing, and Ctrl+C handling.

* **Tests**
  * Added coverage verifying redraw behavior for resize and keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->