### PR TITLE
chore(ci): use personal git identity for automated commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
       # Create temporary tag for changelog generation
       - name: Create temporary tag
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "unhappychoice@gmail.com"
+          git config --local user.name "Yuji Ueki"
           git add Cargo.toml Cargo.lock flake.nix
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git tag ${{ steps.version.outputs.new_version }}
@@ -258,8 +258,8 @@ jobs:
           fi
 
           # Commit and push the updated flake.nix
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "unhappychoice@gmail.com"
+          git config --local user.name "Yuji Ueki"
           git add flake.nix
           git commit -m "chore: update flake.nix hashes for $VERSION" || echo "No changes to commit"
           git push origin main
@@ -324,8 +324,8 @@ jobs:
           FOURTH_SHA_LINE=$(grep -n 'sha256 "' Formula/gittype.rb | head -4 | tail -1 | cut -d: -f1)
           sed -i "${FOURTH_SHA_LINE}s/sha256 \"[a-f0-9]\+\"/sha256 \"$LINUX_ARM_SHA\"/" Formula/gittype.rb
           
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "unhappychoice@gmail.com"
+          git config --local user.name "Yuji Ueki"
           git add Formula/gittype.rb
           git commit -m "chore: update gittype to $VERSION"
           git push


### PR DESCRIPTION
Automated commits made by GitHub Actions in this repository were authored as a bot (or under an inconsistent name). This switches them to `Yuji Ueki <unhappychoice@gmail.com>` so the history and contribution graph reflect the actual author.

Workflow logic is unchanged — only the configured commit identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the author information recorded by automated release and package update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->