### PR TITLE
feat: add system theme following (auto light/dark mode)

### DIFF
--- a/src/domain/models/color_mode.rs
+++ b/src/domain/models/color_mode.rs
@@ -5,4 +5,5 @@ pub enum ColorMode {
     #[default]
     Dark,
     Light,
+    System,
 }

--- a/src/domain/models/color_scheme.rs
+++ b/src/domain/models/color_scheme.rs
@@ -134,6 +134,9 @@ impl ColorScheme {
         let colors = match color_mode {
             ColorMode::Dark => &theme_file.dark,
             ColorMode::Light => &theme_file.light,
+            // System is resolved to Dark/Light by ThemeService before this is called;
+            // dark is the fallback if it ever reaches here unresolved.
+            ColorMode::System => &theme_file.dark,
         };
 
         Self {

--- a/src/domain/services/appearance_detector.rs
+++ b/src/domain/services/appearance_detector.rs
@@ -1,0 +1,31 @@
+use crate::domain::models::color_mode::ColorMode;
+use shaku::Interface;
+
+/// Detects the OS light/dark appearance preference.
+pub trait AppearanceDetectorInterface: Interface {
+    /// Returns `Some(Dark|Light)` when the OS appearance can be determined,
+    /// `None` when it cannot (unsupported platform, no desktop session, etc).
+    fn detect_color_mode(&self) -> Option<ColorMode>;
+}
+
+/// Always reports undetectable; used as the default injection in test helpers.
+#[cfg(feature = "test-mocks")]
+pub struct NoopAppearanceDetector;
+
+#[cfg(feature = "test-mocks")]
+impl AppearanceDetectorInterface for NoopAppearanceDetector {
+    fn detect_color_mode(&self) -> Option<ColorMode> {
+        None
+    }
+}
+
+/// Returns a fixed mode; gives deterministic resolution in tests.
+#[cfg(feature = "test-mocks")]
+pub struct FixedAppearanceDetector(pub Option<ColorMode>);
+
+#[cfg(feature = "test-mocks")]
+impl AppearanceDetectorInterface for FixedAppearanceDetector {
+    fn detect_color_mode(&self) -> Option<ColorMode> {
+        self.0.clone()
+    }
+}

--- a/src/domain/services/mod.rs
+++ b/src/domain/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics_service;
+pub mod appearance_detector;
 pub mod challenge_generator;
 pub mod config_service;
 pub mod context_loader;

--- a/src/domain/services/theme_service.rs
+++ b/src/domain/services/theme_service.rs
@@ -3,6 +3,7 @@ use crate::domain::models::color_scheme::{
     ColorScheme, CustomThemeFile, SerializableColor, ThemeFile,
 };
 use crate::domain::models::theme::Theme;
+use crate::domain::services::appearance_detector::AppearanceDetectorInterface;
 use crate::domain::services::config_service::ConfigServiceInterface;
 use crate::infrastructure::storage::app_data_provider::AppDataProvider;
 use crate::infrastructure::storage::file_storage::{FileStorage, FileStorageInterface};
@@ -15,6 +16,7 @@ use std::sync::{Arc, RwLock};
 pub struct ThemeServiceState {
     current_theme: Theme,
     current_color_mode: ColorMode,
+    effective_color_mode: ColorMode,
     // Map of (theme_id, color_mode) -> (lang_name -> Color)
     language_colors: HashMap<(String, ColorMode), HashMap<String, ratatui::style::Color>>,
 }
@@ -24,6 +26,7 @@ impl Default for ThemeServiceState {
         Self {
             current_theme: Theme::default(),
             current_color_mode: ColorMode::Dark,
+            effective_color_mode: ColorMode::Dark,
             language_colors: HashMap::new(),
         }
     }
@@ -50,6 +53,8 @@ pub struct ThemeService {
     file_storage: Arc<dyn FileStorageInterface>,
     #[shaku(inject)]
     config_service: Arc<dyn ConfigServiceInterface>,
+    #[shaku(inject)]
+    appearance_detector: Arc<dyn AppearanceDetectorInterface>,
 }
 
 impl AppDataProvider for ThemeService {}
@@ -57,17 +62,58 @@ impl AppDataProvider for ThemeService {}
 impl ThemeService {
     #[cfg(feature = "test-mocks")]
     pub fn new_for_test(current_theme: Theme, current_color_mode: ColorMode) -> Self {
+        use crate::domain::services::appearance_detector::NoopAppearanceDetector;
+        Self::new_for_test_with_appearance(
+            current_theme,
+            current_color_mode,
+            Arc::new(NoopAppearanceDetector),
+        )
+    }
+
+    #[cfg(feature = "test-mocks")]
+    pub fn new_for_test_with_appearance(
+        current_theme: Theme,
+        current_color_mode: ColorMode,
+        appearance_detector: Arc<dyn AppearanceDetectorInterface>,
+    ) -> Self {
         use crate::domain::services::config_service::ConfigService;
+        let effective_color_mode =
+            Self::resolve_color_mode(appearance_detector.as_ref(), current_color_mode.clone());
         let file_storage = Arc::new(FileStorage::new());
         let config_service = Arc::new(ConfigService::new(file_storage.clone()).unwrap());
         Self {
             state: RwLock::new(ThemeServiceState {
                 current_theme,
                 current_color_mode,
+                effective_color_mode,
                 language_colors: HashMap::new(),
             }),
             file_storage,
             config_service,
+            appearance_detector,
+        }
+    }
+    /// Load language colors without touching the configured mode.
+    /// Test-only seam: `init()` re-reads the persisted config and would
+    /// overwrite the mode set by the test constructors.
+    #[cfg(feature = "test-mocks")]
+    pub fn init_language_colors_for_test(&self) {
+        let language_colors = Self::load_all_language_colors();
+        self.state.write().unwrap().language_colors = language_colors;
+    }
+
+    /// Resolve the configured mode to an effective Dark/Light mode.
+    /// `System` maps to the OS appearance; falls back to Dark when undetectable.
+    fn resolve_color_mode(
+        detector: &dyn AppearanceDetectorInterface,
+        configured: ColorMode,
+    ) -> ColorMode {
+        match configured {
+            ColorMode::Dark | ColorMode::Light => configured,
+            ColorMode::System => detector.detect_color_mode().unwrap_or_else(|| {
+                log::warn!("Could not detect the system appearance; using Dark as fallback");
+                ColorMode::Dark
+            }),
         }
     }
 
@@ -76,6 +122,8 @@ impl ThemeService {
         match color_mode {
             ColorMode::Light => theme.light.clone(),
             ColorMode::Dark => theme.dark.clone(),
+            // System is resolved to Dark/Light before this is called; dark is the fallback.
+            ColorMode::System => theme.dark.clone(),
         }
     }
 
@@ -173,9 +221,15 @@ impl ThemeServiceInterface for ThemeService {
         // Load all language colors
         let language_colors = Self::load_all_language_colors();
 
+        let effective_color_mode = Self::resolve_color_mode(
+            self.appearance_detector.as_ref(),
+            current_color_mode.clone(),
+        );
+
         let mut state = self.state.write().unwrap();
         state.current_theme = current_theme;
         state.current_color_mode = current_color_mode;
+        state.effective_color_mode = effective_color_mode;
         state.language_colors = language_colors;
         Ok(())
     }
@@ -220,12 +274,16 @@ impl ThemeServiceInterface for ThemeService {
     }
 
     fn set_current_color_mode(&self, color_mode: ColorMode) {
-        self.state.write().unwrap().current_color_mode = color_mode;
+        let effective_color_mode =
+            Self::resolve_color_mode(self.appearance_detector.as_ref(), color_mode.clone());
+        let mut state = self.state.write().unwrap();
+        state.current_color_mode = color_mode;
+        state.effective_color_mode = effective_color_mode;
     }
 
     fn get_current_color_scheme(&self) -> ColorScheme {
         let state = self.state.read().unwrap();
-        Self::get_color_scheme(&state.current_theme, &state.current_color_mode)
+        Self::get_color_scheme(&state.current_theme, &state.effective_color_mode)
     }
 
     fn get_colors(&self) -> Colors {
@@ -235,9 +293,9 @@ impl ThemeServiceInterface for ThemeService {
     fn get_color_for_language(&self, language_name: &str) -> ratatui::style::Color {
         let state = self.state.read().unwrap();
         let key = if state.current_theme.id == "ascii" {
-            ("ascii".to_string(), state.current_color_mode.clone())
+            ("ascii".to_string(), state.effective_color_mode.clone())
         } else {
-            ("default".to_string(), state.current_color_mode.clone())
+            ("default".to_string(), state.effective_color_mode.clone())
         };
 
         state

--- a/src/infrastructure/appearance.rs
+++ b/src/infrastructure/appearance.rs
@@ -1,0 +1,202 @@
+use crate::domain::models::color_mode::ColorMode;
+use crate::domain::services::appearance_detector::AppearanceDetectorInterface;
+use std::process::Command;
+
+/// Detects the OS light/dark appearance using only native platform tools.
+/// Detection is best-effort on every platform; any failure degrades to `None`.
+#[derive(shaku::Component)]
+#[shaku(interface = AppearanceDetectorInterface)]
+pub struct OsAppearanceDetector;
+
+impl AppearanceDetectorInterface for OsAppearanceDetector {
+    fn detect_color_mode(&self) -> Option<ColorMode> {
+        detect_system_color_mode()
+    }
+}
+
+/// Detect the system appearance by platform. Never panics.
+pub(crate) fn detect_system_color_mode() -> Option<ColorMode> {
+    #[cfg(target_os = "macos")]
+    {
+        let output = Command::new("defaults")
+            .args(["read", "-g", "AppleInterfaceStyle"])
+            .output();
+        match output {
+            Ok(output) => parse_macos_interface_style(
+                &String::from_utf8_lossy(&output.stdout),
+                output.status.success(),
+            ),
+            Err(_) => None,
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let output = Command::new("reg")
+            .args([
+                "query",
+                "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                "/v",
+                "AppsUseLightTheme",
+            ])
+            .output()
+            .ok()?;
+        parse_windows_apps_use_light_theme(&String::from_utf8_lossy(&output.stdout))
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        detect_linux_color_mode()
+    }
+
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        let _: Option<ColorMode> = None;
+        None
+    }
+}
+
+/// Linux/BSD detection chain: XDG Desktop Portal (via busctl), then gsettings,
+/// then KDE's kdeglobals. First successful result wins.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn detect_linux_color_mode() -> Option<ColorMode> {
+    if let Some(mode) = detect_busctl_color_scheme() {
+        return Some(mode);
+    }
+    if let Some(mode) = detect_gsettings_color_scheme() {
+        return Some(mode);
+    }
+    detect_kdeglobals_color_scheme()
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn detect_busctl_color_scheme() -> Option<ColorMode> {
+    let output = Command::new("busctl")
+        .args([
+            "--user",
+            "call",
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            "org.freedesktop.portal.Settings",
+            "Read",
+            "ss",
+            "org.freedesktop.appearance",
+            "color-scheme",
+        ])
+        .output()
+        .ok()?;
+    parse_busctl_color_scheme(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn detect_gsettings_color_scheme() -> Option<ColorMode> {
+    let output = Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.interface", "color-scheme"])
+        .output()
+        .ok()?;
+    parse_gsettings_color_scheme(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn detect_kdeglobals_color_scheme() -> Option<ColorMode> {
+    let path = dirs::config_dir()?.join("kdeglobals");
+    let contents = std::fs::read_to_string(path).ok()?;
+    parse_kdeglobals(&contents)
+}
+
+/// Portal `color-scheme` output is `u 0|1|2` (0 = no preference, 1 = prefer dark, 2 = prefer light).
+pub(crate) fn parse_busctl_color_scheme(output: &str) -> Option<ColorMode> {
+    let value = output.split_whitespace().last()?.parse::<u32>().ok()?;
+    match value {
+        1 => Some(ColorMode::Dark),
+        2 => Some(ColorMode::Light),
+        _ => None,
+    }
+}
+
+/// gsettings output is `'default'`, `'prefer-dark'`, or `'prefer-light'`.
+pub(crate) fn parse_gsettings_color_scheme(output: &str) -> Option<ColorMode> {
+    if output.contains("prefer-dark") {
+        Some(ColorMode::Dark)
+    } else if output.contains("prefer-light") {
+        Some(ColorMode::Light)
+    } else {
+        None
+    }
+}
+
+/// Only called on Windows; kept compiled everywhere so unit tests can cover its parsing.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn parse_windows_apps_use_light_theme(output: &str) -> Option<ColorMode> {
+    let line = output.lines().find(|l| l.contains("AppsUseLightTheme"))?;
+    if line.contains("0x1") {
+        Some(ColorMode::Light)
+    } else if line.contains("0x0") {
+        Some(ColorMode::Dark)
+    } else {
+        None
+    }
+}
+
+/// Only called on macOS; kept compiled everywhere so unit tests can cover its parsing.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn parse_macos_interface_style(output: &str, ok: bool) -> Option<ColorMode> {
+    if !ok && output.is_empty() {
+        // An absent AppleInterfaceStyle key makes `defaults` exit non-zero; macOS then defaults to light.
+        return Some(ColorMode::Light);
+    }
+    if !ok {
+        return None;
+    }
+    if output.contains("Dark") {
+        Some(ColorMode::Dark)
+    } else {
+        Some(ColorMode::Light)
+    }
+}
+/// KDE stores `ColorScheme=...` under `[General]` in `~/.config/kdeglobals`.
+pub(crate) fn parse_kdeglobals(contents: &str) -> Option<ColorMode> {
+    let mut in_general_section = false;
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            in_general_section = line == "[General]";
+            continue;
+        }
+        if in_general_section {
+            if let Some(value) = line.strip_prefix("ColorScheme=") {
+                if value.contains("Dark") {
+                    return Some(ColorMode::Dark);
+                }
+                if value.contains("Light") {
+                    return Some(ColorMode::Light);
+                }
+                return None;
+            }
+        }
+    }
+    None
+}
+
+/// Test-only wrappers over the platform parsers. Integration tests are a
+/// separate crate and cannot see `pub(crate)` items directly.
+#[cfg(feature = "test-mocks")]
+pub mod for_test {
+    use super::*;
+
+    pub fn parse_busctl_color_scheme(output: &str) -> Option<ColorMode> {
+        super::parse_busctl_color_scheme(output)
+    }
+    pub fn parse_gsettings_color_scheme(output: &str) -> Option<ColorMode> {
+        super::parse_gsettings_color_scheme(output)
+    }
+    pub fn parse_windows_apps_use_light_theme(output: &str) -> Option<ColorMode> {
+        super::parse_windows_apps_use_light_theme(output)
+    }
+    pub fn parse_macos_interface_style(output: &str, ok: bool) -> Option<ColorMode> {
+        super::parse_macos_interface_style(output, ok)
+    }
+    pub fn parse_kdeglobals(contents: &str) -> Option<ColorMode> {
+        super::parse_kdeglobals(contents)
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
+pub mod appearance;
 pub mod browser;
 pub mod console;
 pub mod database;

--- a/src/presentation/di.rs
+++ b/src/presentation/di.rs
@@ -15,6 +15,7 @@ use crate::domain::services::stage_builder_service::StageRepository as StageBuil
 use crate::domain::services::theme_service::ThemeService;
 use crate::domain::services::version_service::VersionService;
 use crate::domain::stores::{ChallengeStore, RepositoryStore, SessionStore};
+use crate::infrastructure::appearance::OsAppearanceDetector;
 use crate::infrastructure::database::daos::{ChallengeDao, RepositoryDao, SessionDao, StageDao};
 use crate::infrastructure::database::database::Database;
 use crate::infrastructure::http::github_api_client::GitHubApiClientFactoryImpl;
@@ -64,6 +65,7 @@ shaku::module! {
             RepositoryService,
             VersionService,
             ConfigService,
+            OsAppearanceDetector,
             ThemeService,
             ScreenManagerFactoryImpl,
             TitleScreen,

--- a/src/presentation/tui/screens/settings_screen.rs
+++ b/src/presentation/tui/screens/settings_screen.rs
@@ -38,7 +38,7 @@ impl SettingsSection {
 
     fn description(&self) -> &'static str {
         match self {
-            SettingsSection::ColorMode => "Choose between dark and light modes",
+            SettingsSection::ColorMode => "Choose between dark, light, and system modes",
             SettingsSection::Theme => "Select theme - preview changes instantly",
         }
     }
@@ -176,6 +176,7 @@ impl SettingsScreen {
                 let text = match mode {
                     ColorMode::Dark => "Dark",
                     ColorMode::Light => "Light",
+                    ColorMode::System => "System",
                 };
                 ListItem::new(text)
             })
@@ -374,7 +375,7 @@ impl Screen for SettingsScreen {
         let _data = data.downcast::<SettingsScreenData>()?;
 
         // Fetch data from theme_service since provider returns empty data
-        let color_modes = vec![ColorMode::Dark, ColorMode::Light];
+        let color_modes = vec![ColorMode::Dark, ColorMode::Light, ColorMode::System];
         let themes = self.theme_service.get_available_themes();
         let current_theme = self.theme_service.get_current_theme();
         let current_color_mode = self.theme_service.get_current_color_mode();

--- a/tests/integration/screens/mocks/settings_screen_mock.rs
+++ b/tests/integration/screens/mocks/settings_screen_mock.rs
@@ -10,7 +10,7 @@ impl ScreenDataProvider for MockSettingsScreenDataProvider {
     fn provide(&self) -> Result<Box<dyn std::any::Any>> {
         let themes = Theme::all_themes();
         let data = SettingsScreenData {
-            color_modes: vec![ColorMode::Dark, ColorMode::Light],
+            color_modes: vec![ColorMode::Dark, ColorMode::Light, ColorMode::System],
             themes: themes.clone(),
             current_theme: themes.first().cloned().unwrap_or_default(),
             current_color_mode: ColorMode::Dark,

--- a/tests/integration/screens/snapshots/r#mod__integration__screens__settings_screen_test__settings_screen_snapshot_color_mode.snap
+++ b/tests/integration/screens/snapshots/r#mod__integration__screens__settings_screen_test__settings_screen_snapshot_color_mode.snap
@@ -6,9 +6,9 @@ expression: output
 │ Color Mode │ Theme                                                                                                   │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Color Mode────────────────────────────────────────────────┐┌Description───────────────────────────────────────────────┐
-│  Dark                                                    ││  Choose between dark and light modes                     │
+│  Dark                                                    ││  Choose between dark, light, and system modes            │
 │  Light                                                   ││                                                          │
-│                                                          ││                                                          │
+│  System                                                  ││                                                          │
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 │                                                          ││                                                          │

--- a/tests/unit/domain/models/config_tests.rs
+++ b/tests/unit/domain/models/config_tests.rs
@@ -189,3 +189,14 @@ fn test_theme_config_clone() {
     assert_eq!(config.current_theme_id, cloned.current_theme_id);
     assert_eq!(config.current_color_mode, cloned.current_color_mode);
 }
+#[test]
+fn test_theme_config_serialize_deserialize_system_mode() {
+    let config = ThemeConfig {
+        current_theme_id: "default".to_string(),
+        current_color_mode: ColorMode::System,
+    };
+    let serialized = serde_json::to_string(&config).unwrap();
+    assert!(serialized.contains("\"System\""));
+    let deserialized: ThemeConfig = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.current_color_mode, ColorMode::System);
+}

--- a/tests/unit/domain/services/theme_manager_tests.rs
+++ b/tests/unit/domain/services/theme_manager_tests.rs
@@ -236,3 +236,90 @@ fn get_color_for_language_picks_ascii_key_when_current_theme_is_ascii() {
 
     assert_eq!(color, ratatui::style::Color::White);
 }
+
+#[test]
+fn system_mode_resolves_to_dark_scheme() {
+    let manager = ThemeService::new_for_test_with_appearance(
+        Theme::default(),
+        ColorMode::System,
+        std::sync::Arc::new(
+            gittype::domain::services::appearance_detector::FixedAppearanceDetector(Some(
+                ColorMode::Dark,
+            )),
+        ),
+    );
+    assert_eq!(manager.get_current_color_scheme(), Theme::default().dark);
+}
+
+#[test]
+fn system_mode_resolves_to_light_scheme() {
+    let manager = ThemeService::new_for_test_with_appearance(
+        Theme::default(),
+        ColorMode::System,
+        std::sync::Arc::new(
+            gittype::domain::services::appearance_detector::FixedAppearanceDetector(Some(
+                ColorMode::Light,
+            )),
+        ),
+    );
+    assert_eq!(manager.get_current_color_scheme(), Theme::default().light);
+}
+
+#[test]
+fn system_mode_falls_back_to_dark_when_undetectable() {
+    let manager = ThemeService::new_for_test(Theme::default(), ColorMode::System);
+    assert_eq!(manager.get_current_color_mode(), ColorMode::System);
+    assert_eq!(manager.get_current_color_scheme(), Theme::default().dark);
+}
+
+#[test]
+fn get_current_color_mode_returns_system_when_configured() {
+    let manager = ThemeService::new_for_test(Theme::default(), ColorMode::System);
+    assert_eq!(manager.get_current_color_mode(), ColorMode::System);
+}
+
+#[test]
+fn set_current_color_mode_system_applies_effective() {
+    let manager = ThemeService::new_for_test_with_appearance(
+        Theme::default(),
+        ColorMode::Dark,
+        std::sync::Arc::new(
+            gittype::domain::services::appearance_detector::FixedAppearanceDetector(Some(
+                ColorMode::Light,
+            )),
+        ),
+    );
+    manager.set_current_color_mode(ColorMode::System);
+    assert_eq!(manager.get_current_color_mode(), ColorMode::System);
+    assert_eq!(manager.get_current_color_scheme(), Theme::default().light);
+}
+
+#[test]
+fn get_color_for_language_system_mode_uses_effective_key() {
+    let system_light = ThemeService::new_for_test_with_appearance(
+        Theme::default(),
+        ColorMode::System,
+        std::sync::Arc::new(
+            gittype::domain::services::appearance_detector::FixedAppearanceDetector(Some(
+                ColorMode::Light,
+            )),
+        ),
+    );
+    system_light.init_language_colors_for_test();
+
+    let explicit_light = ThemeService::new_for_test(Theme::default(), ColorMode::Light);
+    explicit_light.init_language_colors_for_test();
+    assert_eq!(
+        system_light.get_color_for_language("python"),
+        explicit_light.get_color_for_language("python")
+    );
+
+    // The effective (Light) key must differ from a Dark-resolved lookup,
+    // proving the key uses the effective mode rather than `System`.
+    let explicit_dark = ThemeService::new_for_test(Theme::default(), ColorMode::Dark);
+    explicit_dark.init_language_colors_for_test();
+    assert_ne!(
+        system_light.get_color_for_language("python"),
+        explicit_dark.get_color_for_language("python")
+    );
+}

--- a/tests/unit/infrastructure/appearance_tests.rs
+++ b/tests/unit/infrastructure/appearance_tests.rs
@@ -1,0 +1,132 @@
+use gittype::domain::models::color_mode::ColorMode;
+use gittype::infrastructure::appearance::for_test::{
+    parse_busctl_color_scheme, parse_gsettings_color_scheme, parse_kdeglobals,
+    parse_macos_interface_style, parse_windows_apps_use_light_theme,
+};
+
+#[test]
+fn busctl_parses_prefer_dark() {
+    // `busctl --user call ... Read ss ...` prints the (v) reply as `v v u N`.
+    assert_eq!(parse_busctl_color_scheme("v v u 1"), Some(ColorMode::Dark));
+}
+
+#[test]
+fn busctl_parses_prefer_light() {
+    assert_eq!(parse_busctl_color_scheme("v v u 2"), Some(ColorMode::Light));
+}
+
+#[test]
+fn busctl_parses_no_preference_as_none() {
+    assert_eq!(parse_busctl_color_scheme("v v u 0"), None);
+}
+
+#[test]
+fn busctl_rejects_garbage() {
+    assert_eq!(parse_busctl_color_scheme(""), None);
+    assert_eq!(parse_busctl_color_scheme("variant u"), None);
+}
+
+#[test]
+fn gsettings_parses_prefer_dark() {
+    assert_eq!(
+        parse_gsettings_color_scheme("'prefer-dark'"),
+        Some(ColorMode::Dark)
+    );
+}
+
+#[test]
+fn gsettings_parses_prefer_light() {
+    assert_eq!(
+        parse_gsettings_color_scheme("'prefer-light'"),
+        Some(ColorMode::Light)
+    );
+}
+
+#[test]
+fn gsettings_parses_default_as_none() {
+    assert_eq!(parse_gsettings_color_scheme("'default'"), None);
+}
+
+#[test]
+fn windows_parses_light_theme() {
+    let output = "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize\n    AppsUseLightTheme    REG_DWORD    0x1\n";
+    assert_eq!(
+        parse_windows_apps_use_light_theme(output),
+        Some(ColorMode::Light)
+    );
+}
+
+#[test]
+fn windows_parses_dark_theme() {
+    let output = "    AppsUseLightTheme    REG_DWORD    0x0\n";
+    assert_eq!(
+        parse_windows_apps_use_light_theme(output),
+        Some(ColorMode::Dark)
+    );
+}
+
+#[test]
+fn windows_rejects_missing_value() {
+    assert_eq!(parse_windows_apps_use_light_theme("no such key"), None);
+}
+
+#[test]
+fn macos_parses_dark() {
+    assert_eq!(
+        parse_macos_interface_style("Dark", true),
+        Some(ColorMode::Dark)
+    );
+}
+
+#[test]
+fn macos_missing_key_means_light() {
+    // `defaults` exits non-zero with empty output when AppleInterfaceStyle is absent.
+    assert_eq!(
+        parse_macos_interface_style("", false),
+        Some(ColorMode::Light)
+    );
+}
+
+#[test]
+fn macos_other_output_means_light() {
+    assert_eq!(
+        parse_macos_interface_style("something unexpected", true),
+        Some(ColorMode::Light)
+    );
+}
+
+#[test]
+fn kdeglobals_parses_dark_scheme() {
+    let contents = "[General]\nColorScheme=BreezeDark\n";
+    assert_eq!(parse_kdeglobals(contents), Some(ColorMode::Dark));
+}
+
+#[test]
+fn kdeglobals_parses_light_scheme() {
+    let contents = "[General]\nColorScheme=BreezeLight\n";
+    assert_eq!(parse_kdeglobals(contents), Some(ColorMode::Light));
+}
+
+#[test]
+fn kdeglobals_ambiguous_scheme_is_none() {
+    let contents = "[General]\nColorScheme=Breeze\n";
+    assert_eq!(parse_kdeglobals(contents), None);
+}
+
+#[test]
+fn kdeglobals_color_scheme_in_other_section_is_none() {
+    let contents = "[KDE]\nColorScheme=BreezeDark\n";
+    assert_eq!(parse_kdeglobals(contents), None);
+}
+
+#[test]
+fn kdeglobals_missing_section_is_none() {
+    let contents = "[Colors:View]\nColorScheme=BreezeDark\n";
+    assert_eq!(parse_kdeglobals(contents), None);
+}
+
+#[test]
+fn kdeglobals_ignores_other_keys_in_general() {
+    let contents = "[General]\nColorScheme=Noctalia\nColorSchemeHash=2c3f\n\n[KDE]\nSingleClick=true\n";
+    assert_eq!(parse_kdeglobals(contents), None);
+}


### PR DESCRIPTION
## Summary

Adds a `System` (auto) color mode that follows the operating system's light/dark appearance, so the UI automatically matches the system theme without a manual choice.

## Changes

- `ColorMode` gains a `System` variant; `ThemeService` resolves it to an effective Dark/Light mode at startup and whenever the mode is changed, falling back to Dark (with a warning) when the OS preference cannot be determined.
- Zero-dependency OS appearance detection using native tools per platform:
  - macOS: `defaults read -g AppleInterfaceStyle`
  - Windows: registry `AppsUseLightTheme` value
  - Linux/BSD: XDG Desktop Portal via `busctl`, then `gsettings`, then KDE `kdeglobals`
- Settings screen gains a third "System" entry in the Color Mode list; the choice persists in `~/.gittype/config.json` and applies immediately when selected.
- Manual Dark/Light behavior and the Dark default are unchanged (System is opt-in).

## Verification

- 2776 tests pass, including new unit tests for System resolution, detector output parsers, and config JSON roundtrip.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.
- Settings color-mode snapshot updated (adds the System row and new section description).

## Notes

- Live re-resolution while the app runs (OS theme change detected mid-session) is intentionally left as a follow-up; resolution currently happens at startup and on selection in Settings.
- TUI screenshots are not available from this headless environment; the settings screen is covered by the updated insta snapshot.

## AI assistance

This PR was created with the assistance of [oh-my-pi](https://github.com/can1357/oh-my-pi).

Closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **System** color mode option alongside Dark and Light.
  * System mode automatically follows the operating system’s appearance settings.
  * Added fallback behavior to use Dark mode when system appearance cannot be detected.
  * Updated settings screens and theme handling to support the new mode.
* **Tests**
  * Added coverage for system-mode persistence, resolution, fallback behavior, and platform appearance detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->