### PR TITLE
fix(nix): update nixpkgs to fix crates.io 403 on crate downloads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Unblocks the `Nix Build` check, which is currently red on every open PR (#496, #497).

## Cause

`nix build .#unstable` fails while vendoring crates:

```
error: builder for '/nix/store/...-crate-ansi-to-tui-8.0.1.tar.gz.drv' failed with exit code 1
  > trying https://crates.io/api/v1/crates/ansi-to-tui/8.0.1/download
  > curl: (22) The requested URL returned error: 403
  > error: cannot download crate-ansi-to-tui-8.0.1.tar.gz from any mirror
```

crates.io now rejects requests that carry the default curl User-Agent, which is what nixpkgs `fetchurl` sends:

```
$ curl -o /dev/null -w '%{http_code}' -A 'curl/8.5.0' -L https://crates.io/api/v1/crates/ansi-to-tui/8.0.1/download
403
$ curl -o /dev/null -w '%{http_code}' -A 'Mozilla/5.0'  -L https://crates.io/api/v1/crates/ansi-to-tui/8.0.1/download
200
```

It is not a flake or a transient error — re-running the job reproduces it identically. Only crates missing from `cache.nixos.org` are affected, which is why it surfaced now: `ansi-to-tui` 8.0.1 happens not to be cached, so it is the first crate that has to be fetched for real.

## Fix

The pinned nixpkgs (`64c08a7`, 2026-05-23) still builds the download URL from `https://crates.io/api/v1/crates`. Upstream has since switched `importCargoLock` to the `static.crates.io` CDN, which does not filter on User-Agent. Moving the input forward to `34ab990` (2026-08-31) picks that up.

## Verification

```
$ nix build --no-link '.#unstable.cargoDeps'   # exit 0 — ansi-to-tui and all other crates vendor cleanly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)